### PR TITLE
#19 [FEAT] JWT 인증 및 인가 구현

### DIFF
--- a/src/main/java/com/moonspoon/moonspoon/MoonspoonApplication.java
+++ b/src/main/java/com/moonspoon/moonspoon/MoonspoonApplication.java
@@ -4,9 +4,8 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-//@SpringBootApplication
+@SpringBootApplication
 //시큐리티 일시중지
-@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class MoonspoonApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/moonspoon/moonspoon/dto/request/UserLoginRequest.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/request/UserLoginRequest.java
@@ -1,0 +1,13 @@
+package com.moonspoon.moonspoon.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserLoginRequest {
+    private String username;
+    private String password;
+
+}

--- a/src/main/java/com/moonspoon/moonspoon/init/InitDB.java
+++ b/src/main/java/com/moonspoon/moonspoon/init/InitDB.java
@@ -1,6 +1,7 @@
 package com.moonspoon.moonspoon.init;
 
 import com.moonspoon.moonspoon.domain.User;
+import com.moonspoon.moonspoon.domain.UserRole;
 import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ public class InitDB {
             User user = new User();
             user.setUsername("dd");
             user.setPassword(passwordEncoder.encode("dd"));
+            user.setRole(UserRole.USER);
             em.persist(user);
 
         }

--- a/src/main/java/com/moonspoon/moonspoon/init/InitDB.java
+++ b/src/main/java/com/moonspoon/moonspoon/init/InitDB.java
@@ -1,5 +1,35 @@
 package com.moonspoon.moonspoon.init;
 
-public class InitDB {
+import com.moonspoon.moonspoon.domain.User;
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
+@Component
+@RequiredArgsConstructor
+public class InitDB {
+    private final InitService initService;
+
+    @PostConstruct
+    public void init(){
+        initService.dbInit1();
+    }
+
+    @Component
+    @RequiredArgsConstructor
+    @Transactional
+    static class InitService{
+        private final EntityManager em;
+        private final PasswordEncoder passwordEncoder;
+        public void dbInit1(){
+            User user = new User();
+            user.setUsername("dd");
+            user.setPassword(passwordEncoder.encode("dd"));
+            em.persist(user);
+
+        }
+    }
 }

--- a/src/main/java/com/moonspoon/moonspoon/repository/UserRepository.java
+++ b/src/main/java/com/moonspoon/moonspoon/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.moonspoon.moonspoon.repository;
+
+import com.moonspoon.moonspoon.domain.User;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository {
+    @Query("select u from User u where u.username = :username")
+    User findByUsername(String username);
+}

--- a/src/main/java/com/moonspoon/moonspoon/repository/UserRepository.java
+++ b/src/main/java/com/moonspoon/moonspoon/repository/UserRepository.java
@@ -1,11 +1,12 @@
 package com.moonspoon.moonspoon.repository;
 
 import com.moonspoon.moonspoon.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-@Repository
-public interface UserRepository {
+
+public interface UserRepository extends JpaRepository<User, Long> {
     @Query("select u from User u where u.username = :username")
     User findByUsername(String username);
 }

--- a/src/main/java/com/moonspoon/moonspoon/repository/UserRepository.java
+++ b/src/main/java/com/moonspoon/moonspoon/repository/UserRepository.java
@@ -3,10 +3,10 @@ package com.moonspoon.moonspoon.repository;
 import com.moonspoon.moonspoon.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.repository.query.Param;
 
 
 public interface UserRepository extends JpaRepository<User, Long> {
     @Query("select u from User u where u.username = :username")
-    User findByUsername(String username);
+    User findByUsername(@Param("username") String username);
 }

--- a/src/main/java/com/moonspoon/moonspoon/repository/WorkbookRepository.java
+++ b/src/main/java/com/moonspoon/moonspoon/repository/WorkbookRepository.java
@@ -4,6 +4,6 @@ import com.moonspoon.moonspoon.domain.Workbook;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
+
 public interface WorkbookRepository extends JpaRepository<Workbook, Long> {
 }

--- a/src/main/java/com/moonspoon/moonspoon/security/CorsMvcConfig.java
+++ b/src/main/java/com/moonspoon/moonspoon/security/CorsMvcConfig.java
@@ -1,0 +1,16 @@
+package com.moonspoon.moonspoon.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry corsRegistry) {
+
+        corsRegistry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000");
+    }
+}

--- a/src/main/java/com/moonspoon/moonspoon/security/CustomUserDetails.java
+++ b/src/main/java/com/moonspoon/moonspoon/security/CustomUserDetails.java
@@ -1,0 +1,66 @@
+package com.moonspoon.moonspoon.security;
+
+import com.moonspoon.moonspoon.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+
+            @Override
+            public String getAuthority() {
+                return user.getRole().name();
+            }
+        });
+
+        return collection;
+    }
+
+    @Override
+    public String getPassword() {
+
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+
+        return user.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+
+        return true;
+    }
+}

--- a/src/main/java/com/moonspoon/moonspoon/security/CustomUserDetailsService.java
+++ b/src/main/java/com/moonspoon/moonspoon/security/CustomUserDetailsService.java
@@ -1,0 +1,32 @@
+package com.moonspoon.moonspoon.security;
+
+import com.moonspoon.moonspoon.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+import com.moonspoon.moonspoon.domain.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        //DB에서 조회
+        User user = userRepository.findByUsername(username);
+
+        if (user != null) {
+
+            //UserDetails에 담아서 return하면 AutneticationManager가 검증 함
+            return new CustomUserDetails(user);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/moonspoon/moonspoon/security/JWTFilter.java
+++ b/src/main/java/com/moonspoon/moonspoon/security/JWTFilter.java
@@ -1,0 +1,76 @@
+package com.moonspoon.moonspoon.security;
+
+import com.moonspoon.moonspoon.domain.User;
+import com.moonspoon.moonspoon.domain.UserRole;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JWTFilter extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+
+    public JWTFilter(JWTUtil jwtUtil) {
+
+        this.jwtUtil = jwtUtil;
+    }
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        //request에서 Authorization 헤더를 찾음
+        String authorization= request.getHeader("Authorization");
+
+        //Authorization 헤더 검증
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+
+            System.out.println("token null");
+            filterChain.doFilter(request, response);
+
+            //조건이 해당되면 메소드 종료 (필수)
+            return;
+        }
+
+        System.out.println("authorization now");
+        //Bearer 부분 제거 후 순수 토큰만 획득
+        String token = authorization.split(" ")[1];
+
+        //토큰 소멸 시간 검증
+        if (jwtUtil.isExpired(token)) {
+
+            System.out.println("token expired");
+            filterChain.doFilter(request, response);
+
+            //조건이 해당되면 메소드 종료 (필수)
+            return;
+        }
+
+        //토큰에서 username과 role 획득
+        String username = jwtUtil.getUsername(token);
+        String role = jwtUtil.getRole(token);
+
+        //userEntity를 생성하여 값 set
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword("temppassword");
+        user.setRole(UserRole.valueOf(role));
+
+        //UserDetails에 회원 정보 객체 담기
+        CustomUserDetails customUserDetails = new CustomUserDetails(user);
+
+        //스프링 시큐리티 인증 토큰 생성
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        //세션에 사용자 등록
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/moonspoon/moonspoon/security/JWTUtil.java
+++ b/src/main/java/com/moonspoon/moonspoon/security/JWTUtil.java
@@ -1,0 +1,50 @@
+package com.moonspoon.moonspoon.security;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JWTUtil {
+
+    private SecretKey secretKey;
+
+
+
+    public JWTUtil(@Value("${spring.jwt.secret}")String secret) {
+
+
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String getUsername(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+    }
+
+    public String getRole(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String createJwt(String username, String role, Long expiredMs) {
+
+        return Jwts.builder()
+                .claim("username", username)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/com/moonspoon/moonspoon/security/LoginFilter.java
+++ b/src/main/java/com/moonspoon/moonspoon/security/LoginFilter.java
@@ -1,0 +1,82 @@
+package com.moonspoon.moonspoon.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moonspoon.moonspoon.dto.request.UserLoginRequest;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Iterator;
+
+@RequiredArgsConstructor
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+    private final JWTUtil jwtUtil;
+
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+
+        UserLoginRequest loginDTO = new UserLoginRequest();
+
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            ServletInputStream inputStream = request.getInputStream();
+            String messageBody = StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
+            loginDTO = objectMapper.readValue(messageBody, UserLoginRequest.class);
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        System.out.println(loginDTO.getUsername());
+        //클라이언트 요청에서 username, password 추출
+        String username =  loginDTO.getUsername();
+        String password = loginDTO.getPassword();
+
+        //스프링 시큐리티에서 username과 password를 검증하기 위해서는 token에 담아야 함
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, null);
+
+        //token에 담은 검증을 위한 AuthenticationManager로 전달
+        return authenticationManager.authenticate(authToken);
+    }
+
+    //로그인 성공시 실행하는 메소드 (여기서 JWT를 발급하면 됨)
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
+        //UserDetailsS
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+
+        String username = customUserDetails.getUsername();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+
+        String role = auth.getAuthority();
+
+        String token = jwtUtil.createJwt(username, role, 86400000L);
+
+        response.addHeader("Authorization", "Bearer " + token);
+    }
+
+    //로그인 실패시 실행하는 메소드
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
+        //로그인 실패시 401 응답 코드 반환
+        response.setStatus(401);
+    }
+}

--- a/src/main/java/com/moonspoon/moonspoon/security/SecurityConfig.java
+++ b/src/main/java/com/moonspoon/moonspoon/security/SecurityConfig.java
@@ -1,0 +1,86 @@
+package com.moonspoon.moonspoon.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Collections;
+
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    //AuthenticationManager가 인자로 받을 AuthenticationConfiguraion 객체 생성자 주입
+    private final AuthenticationConfiguration authenticationConfiguration;
+    //JWTUtil 주입
+    private final JWTUtil jwtUtil;
+    //AuthenticationManager Bean 등록
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+
+        return configuration.getAuthenticationManager();
+    }
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors((corsCustomizer -> corsCustomizer.configurationSource(new CorsConfigurationSource() {
+
+                    @Override
+                    public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+
+                        CorsConfiguration configuration = new CorsConfiguration();
+
+                        configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
+                        configuration.setAllowedMethods(Collections.singletonList("*"));
+                        configuration.setAllowCredentials(true);
+                        configuration.setAllowedHeaders(Collections.singletonList("*"));
+                        configuration.setMaxAge(3600L);
+
+                        configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+
+                        return configuration;
+                    }
+                })));
+        http
+                .formLogin((auth)->auth.disable())
+                .httpBasic((auth)->auth.disable())
+                .csrf((auth)->auth.disable());
+
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers( "/**").permitAll()
+                        .requestMatchers("/admin").hasRole("ADMIN")
+                        .anyRequest().authenticated());
+        //JWTFilter 등록
+        http
+                .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class);
+        //필터 추가 LoginFilter()는 인자를 받음 (AuthenticationManager() 메소드에 authenticationConfiguration 객체를 넣어야 함) 따라서 등록 필요
+        http
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+
+        return http.build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/19 -> main

### 변경 사항
API 기반 JWT 로그인을 구현했습니다.

### 테스트 결과

로그인 성공 및 토큰 발급
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/af561708-a51a-4b49-9cd1-4f03f8418c5b)


### 코멘트
UserRepository 를 구현할 때 JpaRepository를 사용했는데, @ repository를 통해 빈으로 등록했다가 오류가 발생했습니다. 이유를 찾아보니 JpaRepository를 상속하면 이미 빈으로 등록된 상태인데, @ repository로 등록하면 빈이 2번 등록이 되어 발생한 현상이었습니다. 

그러면 어떻게 JpaRepository를 상속하면 빈이 등록되는지 찾아보니, 생략된 @EnableJpaRepositories 가 JpaRepository를 빈으로 등록하고 있었습니다. 

따라서 @ repository를 생략하고도 JpaRepository를 상속받으면 빈으로 등록된다는 사실을 알았습니다.

### 참고
https://velog.io/@novo2003/JpaRepository-%EC%99%80-Bean-%EB%93%B1%EB%A1%9D

