### PR TITLE
[FEAT] 문제집 CRUD 회원 인증 적용 (#23)

### DIFF
--- a/src/main/java/com/moonspoon/moonspoon/controller/WorkbookController.java
+++ b/src/main/java/com/moonspoon/moonspoon/controller/WorkbookController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.nio.file.AccessDeniedException;
 import java.util.List;
 
 @RestController
@@ -18,7 +19,7 @@ public class WorkbookController {
     private final WorkbookService workbookService;
 
     @PostMapping("/create")
-    public ResponseEntity<WorkbookResponse> createWorkbook(@RequestBody WorkbookCreateRequest dto){
+    public ResponseEntity<WorkbookResponse> createWorkbook(@RequestBody WorkbookCreateRequest dto) {
         WorkbookResponse response = workbookService.createWorkbook(dto);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/src/main/java/com/moonspoon/moonspoon/controller/WorkbookController.java
+++ b/src/main/java/com/moonspoon/moonspoon/controller/WorkbookController.java
@@ -4,6 +4,7 @@ import com.moonspoon.moonspoon.dto.request.WorkbookCreateRequest;
 import com.moonspoon.moonspoon.dto.request.WorkbookUpdateRequest;
 import com.moonspoon.moonspoon.dto.response.WorkbookResponse;
 import com.moonspoon.moonspoon.service.WorkbookService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +20,7 @@ public class WorkbookController {
     private final WorkbookService workbookService;
 
     @PostMapping("/create")
-    public ResponseEntity<WorkbookResponse> createWorkbook(@RequestBody WorkbookCreateRequest dto) {
+    public ResponseEntity<WorkbookResponse> createWorkbook(@Valid @RequestBody WorkbookCreateRequest dto) {
         WorkbookResponse response = workbookService.createWorkbook(dto);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
@@ -37,7 +38,7 @@ public class WorkbookController {
     }
 
     @PostMapping("/update/{id}")
-    public ResponseEntity<WorkbookResponse> updateWorkbook(@RequestBody WorkbookUpdateRequest dto, @PathVariable("id") Long id){
+    public ResponseEntity<WorkbookResponse> updateWorkbook(@Valid @RequestBody WorkbookUpdateRequest dto, @PathVariable("id") Long id){
         WorkbookResponse response = workbookService.updateWorkbook(id, dto);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/src/main/java/com/moonspoon/moonspoon/domain/User.java
+++ b/src/main/java/com/moonspoon/moonspoon/domain/User.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -25,7 +26,7 @@ public class User {
     private UserRole role;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
-    private List<Workbook> workbooks;
+    private List<Workbook> workbooks = new ArrayList<>();
 
     @Builder
     public User(String username, String name, String password, UserRole role){

--- a/src/main/java/com/moonspoon/moonspoon/domain/Workbook.java
+++ b/src/main/java/com/moonspoon/moonspoon/domain/Workbook.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -32,7 +33,7 @@ public class Workbook {
     private User user;
 
     @OneToMany(mappedBy = "workbook", cascade = CascadeType.REMOVE)
-    private List<Problem> problems;
+    private List<Problem> problems = new ArrayList<>();
 
 
     @Builder

--- a/src/main/java/com/moonspoon/moonspoon/dto/request/WorkbookCreateRequest.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/request/WorkbookCreateRequest.java
@@ -1,6 +1,7 @@
 package com.moonspoon.moonspoon.dto.request;
 
 import com.moonspoon.moonspoon.domain.Workbook;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,6 +12,7 @@ import java.time.LocalDateTime;
 @Setter
 public class WorkbookCreateRequest {
 
+    @NotBlank(message = "문제집 이름은 필수 입력입니다.")
     private String title;
     private String content;
     private LocalDateTime createDate;

--- a/src/main/java/com/moonspoon/moonspoon/dto/request/WorkbookUpdateRequest.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/request/WorkbookUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.moonspoon.moonspoon.dto.request;
 
 import com.moonspoon.moonspoon.domain.Workbook;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 @Setter
 public class WorkbookUpdateRequest {
 
+    @NotBlank(message = "문제집 이름은 필수 입력입니다.")
     private String title;
     private String content;
     private LocalDateTime updateDate;

--- a/src/main/java/com/moonspoon/moonspoon/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/moonspoon/moonspoon/exception/GlobalExceptionHandler.java
@@ -2,7 +2,6 @@ package com.moonspoon.moonspoon.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -14,8 +13,8 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException ex){
+    @ExceptionHandler(NotUserException.class)
+    public ResponseEntity<ErrorResponse> handleNotUserException(NotUserException ex){
         ErrorResponse errorResponse = new ErrorResponse(HttpStatus.FORBIDDEN.value(), ex.getMessage());
         return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN);
     }

--- a/src/main/java/com/moonspoon/moonspoon/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/moonspoon/moonspoon/exception/GlobalExceptionHandler.java
@@ -18,4 +18,10 @@ public class GlobalExceptionHandler {
         ErrorResponse errorResponse = new ErrorResponse(HttpStatus.FORBIDDEN.value(), ex.getMessage());
         return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN);
     }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException ex){
+        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
 }

--- a/src/main/java/com/moonspoon/moonspoon/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/moonspoon/moonspoon/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.moonspoon.moonspoon.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -11,5 +12,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleDuplicateUserException(DuplicateUserException ex){
         ErrorResponse errorResponse = new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage());
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException ex){
+        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.FORBIDDEN.value(), ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN);
     }
 }

--- a/src/main/java/com/moonspoon/moonspoon/exception/NotFoundException.java
+++ b/src/main/java/com/moonspoon/moonspoon/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.moonspoon.moonspoon.exception;
+
+public class NotFoundException extends RuntimeException{
+    public NotFoundException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/moonspoon/moonspoon/exception/NotUserException.java
+++ b/src/main/java/com/moonspoon/moonspoon/exception/NotUserException.java
@@ -1,0 +1,7 @@
+package com.moonspoon.moonspoon.exception;
+
+public class NotUserException extends RuntimeException{
+    public NotUserException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/moonspoon/moonspoon/init/InitDB.java
+++ b/src/main/java/com/moonspoon/moonspoon/init/InitDB.java
@@ -2,12 +2,15 @@ package com.moonspoon.moonspoon.init;
 
 import com.moonspoon.moonspoon.domain.User;
 import com.moonspoon.moonspoon.domain.UserRole;
+import com.moonspoon.moonspoon.domain.Workbook;
 import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Component
 @RequiredArgsConstructor
@@ -32,6 +35,17 @@ public class InitDB {
             user.setPassword(passwordEncoder.encode("dd"));
             user.setRole(UserRole.USER);
             em.persist(user);
+
+            for(int i = 1 ; i <= 3 ; i ++){
+                Workbook w1 = new Workbook();
+                w1.setTitle("w title" + i);
+                w1.setContent("w content" + i);
+                w1.setAuthor(user.getName());
+                w1.setCreateDate(LocalDateTime.now());
+                w1.setUser(user);
+
+                em.persist(w1);
+            }
 
         }
     }

--- a/src/main/java/com/moonspoon/moonspoon/service/WorkbookService.java
+++ b/src/main/java/com/moonspoon/moonspoon/service/WorkbookService.java
@@ -56,7 +56,7 @@ public class WorkbookService {
         Workbook workbook = workbookRepository.findById(id).orElseThrow(
                 () -> new NotFoundException("문제집이 존재하지 않습니다.")
         );
-        if(workbook.getUser().getUsername() != username){
+        if(!workbook.getUser().getUsername().equals(username)){
             throw new NotUserException("권한이 없습니다.");
         }
 

--- a/src/main/java/com/moonspoon/moonspoon/service/WorkbookService.java
+++ b/src/main/java/com/moonspoon/moonspoon/service/WorkbookService.java
@@ -75,8 +75,12 @@ public class WorkbookService {
                 .collect(Collectors.toList());
     }
 
+    //수정
     @Transactional
     public WorkbookResponse updateWorkbook(Long id, WorkbookUpdateRequest dto){
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        validateUser(username);
+
         Workbook workbook = workbookRepository.findById(id).orElseThrow();
         LocalDateTime currentTime = LocalDateTime.now();
         workbook.update(dto.getTitle(), dto.getContent(), currentTime);
@@ -85,6 +89,9 @@ public class WorkbookService {
 
     @Transactional
     public void deleteWorkbook(Long id){
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        validateUser(username);
+
         workbookRepository.deleteById(id);
     }
 

--- a/src/main/java/com/moonspoon/moonspoon/service/WorkbookService.java
+++ b/src/main/java/com/moonspoon/moonspoon/service/WorkbookService.java
@@ -55,7 +55,7 @@ public class WorkbookService {
         Workbook workbook = workbookRepository.findById(id).orElseThrow(
                 () -> new NotFoundException("문제집이 존재하지 않습니다.")
         );
-        if(workbook.getAuthor() != username){
+        if(workbook.getUser().getUsername() != username){
             throw new NotUserException("권한이 없습니다.");
         }
 

--- a/src/main/java/com/moonspoon/moonspoon/service/WorkbookService.java
+++ b/src/main/java/com/moonspoon/moonspoon/service/WorkbookService.java
@@ -34,6 +34,7 @@ public class WorkbookService {
         User user = userRepository.findByUsername(username);
 
         Workbook workbook = WorkbookCreateRequest.toEntity(dto);
+        workbook.setAuthor(user.getName());
         workbook.setCreateDate(LocalDateTime.now());
         workbook.setUser(user);
 

--- a/src/main/java/com/moonspoon/moonspoon/service/WorkbookService.java
+++ b/src/main/java/com/moonspoon/moonspoon/service/WorkbookService.java
@@ -5,6 +5,7 @@ import com.moonspoon.moonspoon.domain.Workbook;
 import com.moonspoon.moonspoon.dto.request.WorkbookCreateRequest;
 import com.moonspoon.moonspoon.dto.request.WorkbookUpdateRequest;
 import com.moonspoon.moonspoon.dto.response.WorkbookResponse;
+import com.moonspoon.moonspoon.exception.NotFoundException;
 import com.moonspoon.moonspoon.exception.NotUserException;
 import com.moonspoon.moonspoon.repository.UserRepository;
 import com.moonspoon.moonspoon.repository.WorkbookRepository;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -46,8 +48,14 @@ public class WorkbookService {
         }
     }
 
+    //단일 조회
     public WorkbookResponse findOneById(Long id){
-        Workbook workbook = workbookRepository.findById(id).orElseThrow();
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        validateUser(username);
+
+        Workbook workbook = workbookRepository.findById(id).orElseThrow(
+                () -> new NotFoundException("문제집이 존재하지 않습니다.")
+        );
         return WorkbookResponse.fromEntity(workbook);
     }
 

--- a/src/main/java/com/moonspoon/moonspoon/service/WorkbookService.java
+++ b/src/main/java/com/moonspoon/moonspoon/service/WorkbookService.java
@@ -65,8 +65,8 @@ public class WorkbookService {
     public List<WorkbookResponse> findAll(){
         String username = SecurityContextHolder.getContext().getAuthentication().getName();
         validateUser(username);
-
-        List<Workbook> workbooks = workbookRepository.findAll();
+        User user = userRepository.findByUsername(username);
+        List<Workbook> workbooks = user.getWorkbooks();
         if(workbooks.isEmpty()){
             throw new NotFoundException("문제집이 존재하지 않습니다.");
         }

--- a/src/main/java/com/moonspoon/moonspoon/service/WorkbookService.java
+++ b/src/main/java/com/moonspoon/moonspoon/service/WorkbookService.java
@@ -87,10 +87,15 @@ public class WorkbookService {
         return WorkbookResponse.fromEntity(workbook);
     }
 
+    //삭제
     @Transactional
     public void deleteWorkbook(Long id){
         String username = SecurityContextHolder.getContext().getAuthentication().getName();
         validateUser(username);
+
+        if(!workbookRepository.existsById(id)){
+            new NotFoundException("문제집이 존재하지 않습니다.");
+        }
 
         workbookRepository.deleteById(id);
     }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/23 -> main

### 변경 사항
문제집 CRUD API 에 회원 인증 ,예외처리를 구현했습니다.
기존 문제집 전체조회 -> 로그인한 회원의 문제집을 전체 조회로 변경했습니다.
Workbook의 저자 닉네임을 설정했습니다.

### 테스트 결과

회원 문제집 생성
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/9b805d26-7e0c-4ec9-9e8d-c3c6d5219063)

문제집 생성 시 공백 처리
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/383b93db-a542-4656-b19c-21f9a8deb551)

비회원 문제집 생성
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/5f2312d0-dc51-4f83-af5a-b7d7eddbc5d3)

회원 문제집 조회
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/f6599b45-7114-4641-870d-a7131e7d8d50)

비회원 문제집 조회
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/3b4b1482-2723-4f0a-b68c-e4dc55944b30)

회원 문제집 전체 조회
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/ace2dac8-f988-4f83-8ed3-f24683440580)


비회원 문제집 전체 조회
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/5960458a-be24-41a9-b130-ff461626c24c)

회원 문제집 수정
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/e7d689dc-820c-4370-bef6-cb626dbe9f5f)

문제집 수정 시 공백 처리
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/58b24166-0782-475d-9b7a-33dfb05784c4)


비회원 문제집 수정
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/1067f5b7-5dd1-4156-a0c6-72694813dbf0)

회원 문제집 삭제
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/70b521ad-a97c-4638-af5c-ac0c0861a91b)
삭제 후 조회
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/8796fa6a-9e55-4f99-9e11-6d29077c842b)

비회원 문제집 삭제
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/ac0112ea-4622-473b-a765-931a2afdb46b)



### 코멘트
사용자를 비교할 때 String 값을 != 연산자로 비교하는 실수를 했었습니다. equals를 생활화합시다.