### PR TITLE
[FEAT] 문제 테스트 기능 구현  (#27)

### DIFF
--- a/src/main/java/com/moonspoon/moonspoon/controller/ProblemController.java
+++ b/src/main/java/com/moonspoon/moonspoon/controller/ProblemController.java
@@ -2,7 +2,9 @@ package com.moonspoon.moonspoon.controller;
 
 import com.moonspoon.moonspoon.dto.request.problem.ProblemCreateRequest;
 import com.moonspoon.moonspoon.dto.request.problem.ProblemUpdateRequest;
+import com.moonspoon.moonspoon.dto.request.test.TestRequest;
 import com.moonspoon.moonspoon.dto.response.ProblemResponse;
+import com.moonspoon.moonspoon.dto.response.TestProblemResponse;
 import com.moonspoon.moonspoon.service.ProblemService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -45,5 +47,12 @@ public class ProblemController {
             @PathVariable("workbookId") Long workbookId, @PathVariable("id") Long id){
         problemService.delete(workbookId, id);
         return new ResponseEntity<>(null, HttpStatus.OK);
+    }
+
+    @PostMapping("/getTest")
+    public ResponseEntity<List<TestProblemResponse>> getTestProblem(
+            @PathVariable("workbookId") Long workbookId, @RequestBody TestRequest dto){
+        List<TestProblemResponse> response = problemService.getTestProblems(workbookId, dto);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/moonspoon/moonspoon/domain/Problem.java
+++ b/src/main/java/com/moonspoon/moonspoon/domain/Problem.java
@@ -20,7 +20,7 @@ public class Problem {
 
     private String solution;
     private String question;
-    private Double accuracy;
+    private double correctRate;
     private LocalDateTime createDate;
     private LocalDateTime updateDate;
 
@@ -33,10 +33,10 @@ public class Problem {
 
 
     @Builder
-    public Problem(String solution, String question, Double accuracy, LocalDateTime createDate, LocalDateTime updateDate, int correctCount, int incorrectCount) {
+    public Problem(String solution, String question, Double correctRate, LocalDateTime createDate, LocalDateTime updateDate, int correctCount, int incorrectCount) {
         this.solution = solution;
         this.question = question;
-        this.accuracy = accuracy;
+        this.correctRate = correctRate;
         this.createDate = createDate;
         this.updateDate = updateDate;
         this.correctCount = correctCount;

--- a/src/main/java/com/moonspoon/moonspoon/dto/request/test/TestRequest.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/request/test/TestRequest.java
@@ -1,0 +1,13 @@
+package com.moonspoon.moonspoon.dto.request.test;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TestRequest {
+    private boolean isRandom;
+    private int problemCount;
+    private String sortOrder;
+
+}

--- a/src/main/java/com/moonspoon/moonspoon/dto/request/test/TestRequest.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/request/test/TestRequest.java
@@ -6,8 +6,9 @@ import lombok.Setter;
 @Getter
 @Setter
 public class TestRequest {
-    private boolean isRandom;
+    private boolean random;
     private int problemCount;
     private String sortOrder;
+
 
 }

--- a/src/main/java/com/moonspoon/moonspoon/dto/response/TestProblemResponse.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/response/TestProblemResponse.java
@@ -1,0 +1,29 @@
+package com.moonspoon.moonspoon.dto.response;
+
+import com.moonspoon.moonspoon.domain.Problem;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TestProblemResponse {
+    private Long id;
+    private String question;
+    private double correctRate;
+
+    @Builder
+    public TestProblemResponse(String question, double correctRate, Long id) {
+        this.id = id;
+        this.question = question;
+        this.correctRate = correctRate;
+    }
+
+    public static TestProblemResponse fromEntity(Problem problem){
+        return TestProblemResponse.builder()
+                .question(problem.getQuestion())
+                .id(problem.getId())
+                .correctRate(problem.getCorrectRate())
+                .build();
+    }
+}

--- a/src/main/java/com/moonspoon/moonspoon/dto/response/TestProblemResponse.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/response/TestProblemResponse.java
@@ -5,24 +5,28 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 public class TestProblemResponse {
     private Long id;
     private String question;
     private double correctRate;
-
+    private LocalDateTime createDate;
     @Builder
-    public TestProblemResponse(String question, double correctRate, Long id) {
+    public TestProblemResponse(String question, double correctRate, Long id, LocalDateTime createDate) {
         this.id = id;
         this.question = question;
         this.correctRate = correctRate;
+        this.createDate = createDate;
     }
 
     public static TestProblemResponse fromEntity(Problem problem){
         return TestProblemResponse.builder()
                 .question(problem.getQuestion())
                 .id(problem.getId())
+                .createDate(problem.getCreateDate())
                 .correctRate(problem.getCorrectRate())
                 .build();
     }

--- a/src/main/java/com/moonspoon/moonspoon/init/InitDB.java
+++ b/src/main/java/com/moonspoon/moonspoon/init/InitDB.java
@@ -49,7 +49,7 @@ public class InitDB {
                     Problem p = new Problem();
                     p.setQuestion("문제" + j);
                     p.setSolution("정답" + j);
-                    p.setCreateDate(LocalDateTime.now());
+                    p.setCreateDate(LocalDateTime.now().plusMinutes(j*10));
                     p.setWorkbook(w1);
                     em.persist(p);
                 }

--- a/src/main/java/com/moonspoon/moonspoon/init/InitDB.java
+++ b/src/main/java/com/moonspoon/moonspoon/init/InitDB.java
@@ -49,6 +49,7 @@ public class InitDB {
                     Problem p = new Problem();
                     p.setQuestion("문제" + j);
                     p.setSolution("정답" + j);
+                    p.setCorrectRate(0.1 * j);
                     p.setCreateDate(LocalDateTime.now().plusMinutes(j*10));
                     p.setWorkbook(w1);
                     em.persist(p);

--- a/src/main/java/com/moonspoon/moonspoon/init/InitDB.java
+++ b/src/main/java/com/moonspoon/moonspoon/init/InitDB.java
@@ -49,7 +49,7 @@ public class InitDB {
                     Problem p = new Problem();
                     p.setQuestion("문제" + j);
                     p.setSolution("정답" + j);
-                    p.setCorrectRate(0.1 * j);
+                    p.setCorrectRate(0.11 * j);
                     p.setCreateDate(LocalDateTime.now().plusMinutes(j*10));
                     p.setWorkbook(w1);
                     em.persist(p);

--- a/src/main/java/com/moonspoon/moonspoon/init/InitDB.java
+++ b/src/main/java/com/moonspoon/moonspoon/init/InitDB.java
@@ -45,10 +45,11 @@ public class InitDB {
                 w1.setAuthor(user.getName());
                 w1.setCreateDate(LocalDateTime.now());
                 w1.setUser(user);
-                for(int j = 1; j <= 3; j++){
+                for(int j = 1; j <= 10; j++){
                     Problem p = new Problem();
                     p.setQuestion("문제" + j);
                     p.setSolution("정답" + j);
+                    p.setCreateDate(LocalDateTime.now());
                     p.setWorkbook(w1);
                     em.persist(p);
                 }
@@ -75,6 +76,7 @@ public class InitDB {
             Problem p = new Problem();
             p.setQuestion("a question");
             p.setSolution("a solution");
+            p.setCreateDate(LocalDateTime.now());
             p.setWorkbook(w);
             em.persist(p);
 

--- a/src/main/java/com/moonspoon/moonspoon/repository/ProblemRepository.java
+++ b/src/main/java/com/moonspoon/moonspoon/repository/ProblemRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ProblemRepository extends JpaRepository<Problem, Long> {
-
+    //todo fetch join 적용
     public List<Problem> findAllByWorkbookId(Long workbookId);
 }
 

--- a/src/main/java/com/moonspoon/moonspoon/service/ProblemService.java
+++ b/src/main/java/com/moonspoon/moonspoon/service/ProblemService.java
@@ -5,7 +5,9 @@ import com.moonspoon.moonspoon.domain.User;
 import com.moonspoon.moonspoon.domain.Workbook;
 import com.moonspoon.moonspoon.dto.request.problem.ProblemCreateRequest;
 import com.moonspoon.moonspoon.dto.request.problem.ProblemUpdateRequest;
+import com.moonspoon.moonspoon.dto.request.test.TestRequest;
 import com.moonspoon.moonspoon.dto.response.ProblemResponse;
+import com.moonspoon.moonspoon.dto.response.TestProblemResponse;
 import com.moonspoon.moonspoon.exception.NotFoundException;
 import com.moonspoon.moonspoon.exception.NotUserException;
 import com.moonspoon.moonspoon.exception.ProblemNotInWorkbook;
@@ -18,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -121,4 +124,57 @@ public class ProblemService {
 
         problemRepository.delete(problem);
     }
+
+    //Test logic
+    public List<TestProblemResponse> getTestProblems(Long workbookId , TestRequest dto){
+        List<Problem> problems = workbookRepository.findById(workbookId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 문제집입니다."))
+                .getProblems();
+        List<Problem> sortedProblems = setOrderProblemList(dto.getSortOrder(), problems);
+
+        if(dto.isRandom()){
+
+        }else{
+
+        }
+
+    }
+
+    private List<Problem> setOrderProblemList(String order, List<Problem> problems){
+        switch(order){
+            case "asc":
+                return sortByCreateDateAsc(problems);
+            case "desc":
+                return sortByCreateDateDesc(problems);
+            case "correctRateAsc":
+                return sortByCorrectRateAsc(problems);
+            case "correctRateDesc":
+                return sortByCorrectRateDesc(problems);
+        }
+    }
+
+    private List<Problem> sortByCorrectRateAsc(List<Problem> problems){
+        return problems.stream()
+                .sorted(Comparator.comparingDouble(Problem::getCorrectRate))
+                .collect(Collectors.toList());
+    }
+
+    private List<Problem> sortByCorrectRateDesc(List<Problem> problems){
+        return problems.stream()
+                .sorted(Comparator.comparingDouble(Problem::getCorrectRate).reversed())
+                .collect(Collectors.toList());
+    }
+
+    private List<Problem> sortByCreateDateAsc(List<Problem> problems){
+        return problems.stream()
+                .sorted(Comparator.comparing(Problem::getCreateDate))
+                .collect(Collectors.toList());
+    }
+
+    private List<Problem> sortByCreateDateDesc(List<Problem> problems){
+        return problems.stream()
+                .sorted(Comparator.comparing(Problem::getCreateDate).reversed())
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/com/moonspoon/moonspoon/service/ProblemService.java
+++ b/src/main/java/com/moonspoon/moonspoon/service/ProblemService.java
@@ -137,20 +137,31 @@ public class ProblemService {
             throw new NotUserException("권한이 없습니다.");
         }
         List<Problem> problems = workbook.getProblems();
+
         int selectCount = dto.getProblemCount();
         if(selectCount > problems.size()){
             selectCount = problems.size();
         }
 
-        if(dto.isRandom()){
-            //원본 리스트 수정
-            Collections.shuffle(problems);
-        }else{
+        if(dto.isRandom() && !dto.getSortOrder().equals("none")){
             //순서 정렬
             problems = setOrderProblemList(dto.getSortOrder(), problems);
+            List<Problem> selectedProblems = problems.subList(0, selectCount);
+            Collections.shuffle(selectedProblems);
+        }else if(dto.isRandom() && dto.getSortOrder().equals("none")){
+            Collections.shuffle(problems);
+            List<Problem> selectedProblems = problems.subList(0, selectCount);
+        }else if(!dto.isRandom() && !dto.getSortOrder().equals("none")){
+            //순서 정렬
+            problems = setOrderProblemList(dto.getSortOrder(), problems);
+            List<Problem> selectedProblems = problems.subList(0, selectCount);
+        }else{
+            //순서 정렬
+            problems = setOrderProblemList("asc", problems);
+            List<Problem> selectedProblems = problems.subList(0, selectCount);
         }
 
-        List<Problem> selectedProblems = problems.subList(0, selectCount);
+
         return selectedProblems.stream()
                 .map(p -> TestProblemResponse.fromEntity(p))
                 .collect(Collectors.toList());
@@ -167,7 +178,7 @@ public class ProblemService {
             case "correctRateDesc":
                 return sortByCorrectRateDesc(problems);
             default:
-                return null;
+                return problems;
         }
     }
 

--- a/src/main/java/com/moonspoon/moonspoon/service/ProblemService.java
+++ b/src/main/java/com/moonspoon/moonspoon/service/ProblemService.java
@@ -138,31 +138,24 @@ public class ProblemService {
         }
         List<Problem> problems = workbook.getProblems();
 
-        int selectCount = dto.getProblemCount();
-        if(selectCount > problems.size()){
-            selectCount = problems.size();
-        }
+        int selectCount = Math.min(dto.getProblemCount(), problems.size());
 
         if(dto.isRandom() && !dto.getSortOrder().equals("none")){
             //순서 정렬
-            problems = setOrderProblemList(dto.getSortOrder(), problems);
-            List<Problem> selectedProblems = problems.subList(0, selectCount);
-            Collections.shuffle(selectedProblems);
+            problems = setOrderProblemList(dto.getSortOrder(), problems).subList(0, selectCount);
+            Collections.shuffle(problems);
         }else if(dto.isRandom() && dto.getSortOrder().equals("none")){
             Collections.shuffle(problems);
-            List<Problem> selectedProblems = problems.subList(0, selectCount);
+            problems = problems.subList(0, selectCount);
         }else if(!dto.isRandom() && !dto.getSortOrder().equals("none")){
             //순서 정렬
-            problems = setOrderProblemList(dto.getSortOrder(), problems);
-            List<Problem> selectedProblems = problems.subList(0, selectCount);
+            problems = setOrderProblemList(dto.getSortOrder(), problems).subList(0, selectCount);
         }else{
             //순서 정렬
-            problems = setOrderProblemList("asc", problems);
-            List<Problem> selectedProblems = problems.subList(0, selectCount);
+            problems = setOrderProblemList("asc", problems).subList(0, selectCount);
         }
 
-
-        return selectedProblems.stream()
+        return problems.stream()
                 .map(p -> TestProblemResponse.fromEntity(p))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/moonspoon/moonspoon/service/WorkbookService.java
+++ b/src/main/java/com/moonspoon/moonspoon/service/WorkbookService.java
@@ -1,9 +1,12 @@
 package com.moonspoon.moonspoon.service;
 
+import com.moonspoon.moonspoon.domain.Problem;
 import com.moonspoon.moonspoon.domain.User;
 import com.moonspoon.moonspoon.domain.Workbook;
+import com.moonspoon.moonspoon.dto.request.test.TestRequest;
 import com.moonspoon.moonspoon.dto.request.workbook.WorkbookCreateRequest;
 import com.moonspoon.moonspoon.dto.request.workbook.WorkbookUpdateRequest;
+import com.moonspoon.moonspoon.dto.response.TestProblemResponse;
 import com.moonspoon.moonspoon.dto.response.WorkbookResponse;
 import com.moonspoon.moonspoon.exception.NotFoundException;
 import com.moonspoon.moonspoon.exception.NotUserException;
@@ -100,5 +103,7 @@ public class WorkbookService {
 
         workbookRepository.deleteById(id);
     }
+
+
 
 }

--- a/vue-cli/src/components/WorkbookDetail.vue
+++ b/vue-cli/src/components/WorkbookDetail.vue
@@ -88,6 +88,10 @@
           <p>출제 순서:</p>
           <div class="radio-group">
             <label>
+              <input type="radio" v-model="testSettings.order" value="none" />
+              <span>기본 값</span>
+            </label>
+            <label>
               <input type="radio" v-model="testSettings.order" value="correctRateAsc" />
               <span>정답률 낮은 순</span>
             </label>


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/27 -> main

### 변경 사항
테스트용 문제 선별, response를 구현했습니다.

### 테스트 결과

정답률 오름차순
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/75cc4f46-d803-4f81-8a15-5284893fdc98)

날짜 내림차순
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/1306f95c-f8ed-4a32-8349-1bc6e2ab6b70)

일반 랜덤
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/b61c86ac-a28c-4036-816c-f8e131c5162a)


정답률 오름차순 + 랜덤
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/0eda8e4f-5acf-40fd-8f9a-3691f6de0035)



### 코멘트
엔티티 설계에 대해 고민했던 부분이었습니다.
테스트 엔티티를 추가적으로 만들고 활용할지, 일회성 DTO로 테스트를 할지 고민했었습니다.

테스트 엔티티를 만들면 관리는 편하겠지만 DB에 부하가 커질 수 있고, DTO로 해결하면 DB 부하는 적겠지만 소스코드가 복잡해지고 테스트 결과 관리가 어렵다는 문제가 있습니다.
 
우선은 일회성 DTO를 통해 테스트를 보는 것으로 하고, 추후 테스트 결과 저장, 분석이 필요하면 테스트 엔티티 설계를 고려하겠습니다.