### PR TITLE
[FEAT] 테스트 결과 API 구현 (#29)

### DIFF
--- a/src/main/java/com/moonspoon/moonspoon/controller/ProblemController.java
+++ b/src/main/java/com/moonspoon/moonspoon/controller/ProblemController.java
@@ -3,8 +3,10 @@ package com.moonspoon.moonspoon.controller;
 import com.moonspoon.moonspoon.dto.request.problem.ProblemCreateRequest;
 import com.moonspoon.moonspoon.dto.request.problem.ProblemUpdateRequest;
 import com.moonspoon.moonspoon.dto.request.test.TestRequest;
+import com.moonspoon.moonspoon.dto.request.test.TestResultRequest;
 import com.moonspoon.moonspoon.dto.response.ProblemResponse;
 import com.moonspoon.moonspoon.dto.response.TestProblemResponse;
+import com.moonspoon.moonspoon.dto.response.TestResultResponse;
 import com.moonspoon.moonspoon.service.ProblemService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -52,7 +54,15 @@ public class ProblemController {
     @PostMapping("/getTest")
     public ResponseEntity<List<TestProblemResponse>> getTestProblem(
             @PathVariable("workbookId") Long workbookId, @RequestBody TestRequest dto){
-        List<TestProblemResponse> response = problemService.getTestProblems(workbookId, dto);
-        return new ResponseEntity<>(response, HttpStatus.OK);
+        List<TestProblemResponse> responses = problemService.getTestProblems(workbookId, dto);
+        return new ResponseEntity<>(responses, HttpStatus.OK);
+    }
+
+    @PostMapping("/getTestResult")
+    public ResponseEntity<List<TestResultResponse>> getTestResultProblem(
+            @PathVariable("workbookId") Long workbookId,
+            @RequestBody List<TestResultRequest> dto){
+        List<TestResultResponse> responses = problemService.getTestResultProblem(workbookId, dto);
+        return new ResponseEntity<>(responses, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/moonspoon/moonspoon/dto/request/problem/ProblemCreateRequest.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/request/problem/ProblemCreateRequest.java
@@ -17,7 +17,7 @@ public class ProblemCreateRequest {
     @NotBlank(message = "정답은 필수 입력 사항입니다.")
     private String solution;
 
-    public static Problem toEntitu(ProblemCreateRequest dto){
+    public static Problem toEntity(ProblemCreateRequest dto){
         return Problem.builder()
                 .question(dto.getQuestion())
                 .solution(dto.getSolution())

--- a/src/main/java/com/moonspoon/moonspoon/dto/request/test/TestResultRequest.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/request/test/TestResultRequest.java
@@ -1,0 +1,12 @@
+package com.moonspoon.moonspoon.dto.request.test;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TestResultRequest {
+    private Long id;
+    private String input;
+
+}

--- a/src/main/java/com/moonspoon/moonspoon/dto/response/TestResultResponse.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/response/TestResultResponse.java
@@ -1,0 +1,27 @@
+package com.moonspoon.moonspoon.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TestResultResponse {
+    private Long id;
+    private String question;
+    private String solution;
+    private String correctRate;
+
+    private String input;
+    private String result;
+
+    @Builder
+    public TestResultResponse(Long id, String question, String solution, String correctRate, String input, String result) {
+        this.id = id;
+        this.question = question;
+        this.solution = solution;
+        this.correctRate = correctRate;
+        this.input = input;
+        this.result = result;
+    }
+}

--- a/src/main/java/com/moonspoon/moonspoon/dto/response/TestResultResponse.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/response/TestResultResponse.java
@@ -1,5 +1,6 @@
 package com.moonspoon.moonspoon.dto.response;
 
+import com.moonspoon.moonspoon.domain.Problem;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -10,18 +11,27 @@ public class TestResultResponse {
     private Long id;
     private String question;
     private String solution;
-    private String correctRate;
+    private double correctRate;
 
     private String input;
     private String result;
 
     @Builder
-    public TestResultResponse(Long id, String question, String solution, String correctRate, String input, String result) {
+    public TestResultResponse(Long id, String question, String solution, double correctRate, String input, String result) {
         this.id = id;
         this.question = question;
         this.solution = solution;
         this.correctRate = correctRate;
         this.input = input;
         this.result = result;
+    }
+
+    public static TestResultResponse fromEntity(Problem problem){
+        return TestResultResponse.builder()
+                .id(problem.getId())
+                .question(problem.getQuestion())
+                .solution(problem.getSolution())
+                .correctRate(problem.getCorrectRate())
+                .build();
     }
 }

--- a/src/main/java/com/moonspoon/moonspoon/init/InitDB.java
+++ b/src/main/java/com/moonspoon/moonspoon/init/InitDB.java
@@ -20,8 +20,8 @@ public class InitDB {
 
     @PostConstruct
     public void init(){
-        initService.dbInit1();
-        initService.dbInit2();
+//        initService.dbInit1();
+//        initService.dbInit2();
     }
 
     @Component

--- a/src/main/java/com/moonspoon/moonspoon/service/ProblemService.java
+++ b/src/main/java/com/moonspoon/moonspoon/service/ProblemService.java
@@ -5,8 +5,10 @@ import com.moonspoon.moonspoon.domain.Workbook;
 import com.moonspoon.moonspoon.dto.request.problem.ProblemCreateRequest;
 import com.moonspoon.moonspoon.dto.request.problem.ProblemUpdateRequest;
 import com.moonspoon.moonspoon.dto.request.test.TestRequest;
+import com.moonspoon.moonspoon.dto.request.test.TestResultRequest;
 import com.moonspoon.moonspoon.dto.response.ProblemResponse;
 import com.moonspoon.moonspoon.dto.response.TestProblemResponse;
+import com.moonspoon.moonspoon.dto.response.TestResultResponse;
 import com.moonspoon.moonspoon.exception.NotFoundException;
 import com.moonspoon.moonspoon.exception.NotUserException;
 import com.moonspoon.moonspoon.exception.ProblemNotInWorkbook;
@@ -171,4 +173,32 @@ public class ProblemService {
                 .collect(Collectors.toList());
     }
 
+    public List<TestResultResponse> getTestResultProblem(Long workbookId, List<TestResultRequest> dto){
+        //검증 로직
+        validateUserAndWorkbook(workbookId);
+        List<TestResultResponse> responses =  dto.stream()
+                .map(d -> {
+                    Problem problem = problemRepository.findById(d.getId()).orElseThrow(
+                            () -> new NotFoundException("존재하지 않는 문제입니다.")
+                    );
+                    TestResultResponse res = TestResultResponse.fromEntity(problem);
+                    res.setInput(d.getInput());
+                    res.setResult(compareStrings(d.getInput(), problem.getSolution()));
+                    return res;
+                        })
+                .collect(Collectors.toList());
+
+        return responses;
+
+    }
+
+    private String compareStrings(String input, String sol){
+        String inputData = input.replaceAll("\\s", "").toLowerCase();
+        String solution = sol.replaceAll("\\s", "").toLowerCase();
+        if(inputData.equals(solution)){
+            return "correct";
+        }else{
+            return "incorrect";
+        }
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/29 -> main

### 변경 사항
테스트 결과를 반환하는 API를 구현했습니다.
입력값과 정답 기준은 공백, 대소문자를 무시하고 비교합니다.

### 테스트 결과
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/7ae9c2d5-b7cc-46d6-a381-c58255759f26)


### 코멘트
서술형의 특징은 답안이 비교적 길고, 글자 하나하나 보다는 의미가 맞아야 정답인 경우가 많습니다. 
그래서 공백과 대소문자를 구분하기 않고 비교하나, 답안이 더 길 경우 글자 하나까지 전부 맞추기는 어렵습니다.
따라서 개인이 직접 채점할 수 있는 시스템을 개발하고 있습니다.

필요하다면 추후 오답이더라도 정답과 입력 답안 String 유사성을 계산하는 로직도 추가할 수 있을 것 같습니다.
