### PR TITLE
[FEAT] 테스트 결과 제출 API 구현 (#31)

### DIFF
--- a/src/main/java/com/moonspoon/moonspoon/controller/ProblemController.java
+++ b/src/main/java/com/moonspoon/moonspoon/controller/ProblemController.java
@@ -4,9 +4,11 @@ import com.moonspoon.moonspoon.dto.request.problem.ProblemCreateRequest;
 import com.moonspoon.moonspoon.dto.request.problem.ProblemUpdateRequest;
 import com.moonspoon.moonspoon.dto.request.test.TestRequest;
 import com.moonspoon.moonspoon.dto.request.test.TestResultRequest;
+import com.moonspoon.moonspoon.dto.request.test.TestResultSubmitRequest;
 import com.moonspoon.moonspoon.dto.response.ProblemResponse;
 import com.moonspoon.moonspoon.dto.response.TestProblemResponse;
 import com.moonspoon.moonspoon.dto.response.TestResultResponse;
+import com.moonspoon.moonspoon.dto.response.TestResultSubmitResponse;
 import com.moonspoon.moonspoon.service.ProblemService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -63,6 +65,13 @@ public class ProblemController {
             @PathVariable("workbookId") Long workbookId,
             @RequestBody List<TestResultRequest> dto){
         List<TestResultResponse> responses = problemService.getTestResultProblem(workbookId, dto);
+        return new ResponseEntity<>(responses, HttpStatus.OK);
+    }
+
+    @PostMapping("/submitTestResult")
+    public ResponseEntity<List<TestResultSubmitResponse>> submitTestResult(
+            @PathVariable("workbookId") Long workbookId, @RequestBody List<TestResultSubmitRequest> dto){
+        List<TestResultSubmitResponse> responses = problemService.testResultSubmit(workbookId, dto);
         return new ResponseEntity<>(responses, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/moonspoon/moonspoon/domain/Problem.java
+++ b/src/main/java/com/moonspoon/moonspoon/domain/Problem.java
@@ -56,4 +56,14 @@ public class Problem {
         this.updateDate = updateDate;
     }
 
+    //비즈니스 로직
+    public void addCorrectCount(){
+        this.correctCount++;
+        this.correctRate = (double)(this.correctCount)/(this.correctCount + this.incorrectCount);
+    }
+
+    public void addIncorrectCount(){
+        this.incorrectCount++;
+        this.correctRate = (double)(this.correctCount)/(this.correctCount + this.incorrectCount);
+    }
 }

--- a/src/main/java/com/moonspoon/moonspoon/domain/Problem.java
+++ b/src/main/java/com/moonspoon/moonspoon/domain/Problem.java
@@ -59,11 +59,13 @@ public class Problem {
     //비즈니스 로직
     public void addCorrectCount(){
         this.correctCount++;
-        this.correctRate = (double)(this.correctCount)/(this.correctCount + this.incorrectCount);
+        double correctRate = (double)(this.correctCount)/(this.correctCount + this.incorrectCount);
+        this.correctRate = Math.round(correctRate*10000)/10000.0;
     }
 
     public void addIncorrectCount(){
         this.incorrectCount++;
-        this.correctRate = (double)(this.correctCount)/(this.correctCount + this.incorrectCount);
+        double correctRate = (double)(this.correctCount)/(this.correctCount + this.incorrectCount);
+        this.correctRate = Math.round(correctRate*10000)/10000.0;
     }
 }

--- a/src/main/java/com/moonspoon/moonspoon/dto/request/test/TestResultSubmitRequest.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/request/test/TestResultSubmitRequest.java
@@ -1,0 +1,12 @@
+package com.moonspoon.moonspoon.dto.request.test;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TestResultSubmitRequest {
+    private Long id;
+    private String result;
+
+}

--- a/src/main/java/com/moonspoon/moonspoon/dto/response/TestResultSubmitResponse.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/response/TestResultSubmitResponse.java
@@ -1,0 +1,31 @@
+package com.moonspoon.moonspoon.dto.response;
+
+import com.moonspoon.moonspoon.domain.Problem;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TestResultSubmitResponse {
+    private Long id;
+    private String result;
+    private int correctCount;
+    private int incorrectCount;
+
+    @Builder
+    public TestResultSubmitResponse(Long id, String result, int correctCount, int incorrectCount) {
+        this.id = id;
+        this.result = result;
+        this.correctCount = correctCount;
+        this.incorrectCount = incorrectCount;
+    }
+
+    public static TestResultSubmitResponse fromEntity(Problem problem){
+        return TestResultSubmitResponse.builder()
+                .correctCount(problem.getCorrectCount())
+                .incorrectCount(problem.getIncorrectCount())
+                .id(problem.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/moonspoon/moonspoon/dto/response/TestResultSubmitResponse.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/response/TestResultSubmitResponse.java
@@ -12,13 +12,15 @@ public class TestResultSubmitResponse {
     private String result;
     private int correctCount;
     private int incorrectCount;
+    private double correctRate;
 
     @Builder
-    public TestResultSubmitResponse(Long id, String result, int correctCount, int incorrectCount) {
+    public TestResultSubmitResponse(Long id, String result, int correctCount, int incorrectCount, double correctRate) {
         this.id = id;
         this.result = result;
         this.correctCount = correctCount;
         this.incorrectCount = incorrectCount;
+        this.correctRate = correctRate;
     }
 
     public static TestResultSubmitResponse fromEntity(Problem problem){
@@ -26,6 +28,7 @@ public class TestResultSubmitResponse {
                 .correctCount(problem.getCorrectCount())
                 .incorrectCount(problem.getIncorrectCount())
                 .id(problem.getId())
+                .correctRate(problem.getCorrectRate())
                 .build();
     }
 }

--- a/src/main/java/com/moonspoon/moonspoon/service/ProblemService.java
+++ b/src/main/java/com/moonspoon/moonspoon/service/ProblemService.java
@@ -201,4 +201,6 @@ public class ProblemService {
             return "incorrect";
         }
     }
+
+
 }

--- a/src/main/java/com/moonspoon/moonspoon/service/ProblemService.java
+++ b/src/main/java/com/moonspoon/moonspoon/service/ProblemService.java
@@ -204,6 +204,7 @@ public class ProblemService {
         }
     }
 
+    @Transactional
     public List<TestResultSubmitResponse> testResultSubmit(Long workbookId, List<TestResultSubmitRequest> dto){
         //검증 로직
         validateUserAndWorkbook(workbookId);
@@ -212,8 +213,8 @@ public class ProblemService {
                     Problem problem = problemRepository.findById(d.getId()).orElseThrow(
                             () -> new NotFoundException("존재하지 않는 문제입니다.")
                     );
-                    TestResultSubmitResponse res =  TestResultSubmitResponse.fromEntity(problem);
                     calculateCorrectRate(problem, d.getResult());
+                    TestResultSubmitResponse res =  TestResultSubmitResponse.fromEntity(problem);
                     res.setResult(d.getResult());
                     return res;
                 })

--- a/src/main/java/com/moonspoon/moonspoon/service/ProblemService.java
+++ b/src/main/java/com/moonspoon/moonspoon/service/ProblemService.java
@@ -6,9 +6,11 @@ import com.moonspoon.moonspoon.dto.request.problem.ProblemCreateRequest;
 import com.moonspoon.moonspoon.dto.request.problem.ProblemUpdateRequest;
 import com.moonspoon.moonspoon.dto.request.test.TestRequest;
 import com.moonspoon.moonspoon.dto.request.test.TestResultRequest;
+import com.moonspoon.moonspoon.dto.request.test.TestResultSubmitRequest;
 import com.moonspoon.moonspoon.dto.response.ProblemResponse;
 import com.moonspoon.moonspoon.dto.response.TestProblemResponse;
 import com.moonspoon.moonspoon.dto.response.TestResultResponse;
+import com.moonspoon.moonspoon.dto.response.TestResultSubmitResponse;
 import com.moonspoon.moonspoon.exception.NotFoundException;
 import com.moonspoon.moonspoon.exception.NotUserException;
 import com.moonspoon.moonspoon.exception.ProblemNotInWorkbook;
@@ -202,5 +204,29 @@ public class ProblemService {
         }
     }
 
+    public List<TestResultSubmitResponse> testResultSubmit(Long workbookId, List<TestResultSubmitRequest> dto){
+        //검증 로직
+        validateUserAndWorkbook(workbookId);
+        List<TestResultSubmitResponse> responses = dto.stream()
+                .map(d -> {
+                    Problem problem = problemRepository.findById(d.getId()).orElseThrow(
+                            () -> new NotFoundException("존재하지 않는 문제입니다.")
+                    );
+                    TestResultSubmitResponse res =  TestResultSubmitResponse.fromEntity(problem);
+                    calculateCorrectRate(problem, d.getResult());
+                    res.setResult(d.getResult());
+                    return res;
+                })
+                .collect(Collectors.toList());
+        return responses;
+    }
+
+    private void calculateCorrectRate(Problem problem, String result){
+        if(result.equals("correct")){
+            problem.addCorrectCount();
+        }else{
+            problem.addIncorrectCount();
+        }
+    }
 
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/31 -> main

### 변경 사항
테스트 결과 제출 api 기능을 구현합니다.
제출하면 해당 문제의 정답, 오답을 카운팅하고 정답률을 계산하여 저장합니다.

### 테스트 결과
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/537b01ae-291c-40d5-b95a-d4211eb36006)


### 코멘트
문제 엔티티에서 정답, 오답 개수 카운트로 값을 변경하기 때문에 @ Transactional을 적용했습니다.