### PR TITLE
[FEAT] 회원가입 입력값 유효성 검사 메시지 구현 (#43)

### DIFF
--- a/src/main/java/com/moonspoon/moonspoon/controller/UserController.java
+++ b/src/main/java/com/moonspoon/moonspoon/controller/UserController.java
@@ -3,6 +3,7 @@ package com.moonspoon.moonspoon.controller;
 import com.moonspoon.moonspoon.dto.request.user.CheckNameRequest;
 import com.moonspoon.moonspoon.dto.request.user.CheckUsernameRequest;
 import com.moonspoon.moonspoon.dto.request.user.UserSignupRequest;
+import com.moonspoon.moonspoon.dto.response.error.DuplicateErrorResponse;
 import com.moonspoon.moonspoon.dto.response.user.UserResponse;
 import com.moonspoon.moonspoon.service.UserService;
 import jakarta.validation.Valid;
@@ -28,13 +29,13 @@ public class UserController {
 
     @PostMapping("/checkUsername")
     public ResponseEntity<?> checkUsername(@Valid @RequestBody CheckUsernameRequest dto){
-        userService.isDuplicatedUsername(dto.getUsername());
-        return new ResponseEntity<>(null, HttpStatus.OK);
+        DuplicateErrorResponse response = userService.isDuplicatedUsername(dto.getUsername());
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
     @PostMapping("/checkName")
     public ResponseEntity<?> checkName(@Valid @RequestBody CheckNameRequest dto){
-        userService.isDuplicatedName(dto.getName());
-        return new ResponseEntity<>(null, HttpStatus.OK);
+        DuplicateErrorResponse response = userService.isDuplicatedName(dto.getName());
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/moonspoon/moonspoon/controller/UserController.java
+++ b/src/main/java/com/moonspoon/moonspoon/controller/UserController.java
@@ -1,7 +1,9 @@
 package com.moonspoon.moonspoon.controller;
 
+import com.moonspoon.moonspoon.dto.request.user.CheckNameRequest;
+import com.moonspoon.moonspoon.dto.request.user.CheckUsernameRequest;
 import com.moonspoon.moonspoon.dto.request.user.UserSignupRequest;
-import com.moonspoon.moonspoon.dto.response.UserResponse;
+import com.moonspoon.moonspoon.dto.response.user.UserResponse;
 import com.moonspoon.moonspoon.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,4 +25,16 @@ public class UserController {
         UserResponse response = userService.signup(dto);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
+
+    @PostMapping("/checkUsername")
+    public ResponseEntity<?> checkUsername(@Valid @RequestBody CheckUsernameRequest dto){
+        userService.isDuplicatedUsername(dto.getUsername());
+        return new ResponseEntity<>(null, HttpStatus.OK);
+    }
+    @PostMapping("/checkName")
+    public ResponseEntity<?> checkName(@Valid @RequestBody CheckNameRequest dto){
+        userService.isDuplicatedName(dto.getName());
+        return new ResponseEntity<>(null, HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/moonspoon/moonspoon/dto/request/user/CheckNameRequest.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/request/user/CheckNameRequest.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 @Setter
 public class CheckNameRequest {
     @NotBlank(message = "이름(닉네임)을 입력하세요.")
-    @Size(min = 4, max = 16)
+    @Size(min = 2, max = 16)
     @Pattern(regexp = "^[a-zA-Z0-9가-힣\\s_-]+$", message = "특수문자는 허용되지 않습니다.")
     private String name;
 }

--- a/src/main/java/com/moonspoon/moonspoon/dto/request/user/CheckNameRequest.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/request/user/CheckNameRequest.java
@@ -1,6 +1,8 @@
 package com.moonspoon.moonspoon.dto.request.user;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,5 +10,7 @@ import lombok.Setter;
 @Setter
 public class CheckNameRequest {
     @NotBlank(message = "이름(닉네임)을 입력하세요.")
+    @Size(min = 4, max = 16)
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣\\s_-]+$", message = "특수문자는 허용되지 않습니다.")
     private String name;
 }

--- a/src/main/java/com/moonspoon/moonspoon/dto/request/user/CheckNameRequest.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/request/user/CheckNameRequest.java
@@ -1,0 +1,12 @@
+package com.moonspoon.moonspoon.dto.request.user;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CheckNameRequest {
+    @NotBlank(message = "이름(닉네임)을 입력하세요.")
+    private String name;
+}

--- a/src/main/java/com/moonspoon/moonspoon/dto/request/user/CheckUsernameRequest.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/request/user/CheckUsernameRequest.java
@@ -1,0 +1,12 @@
+package com.moonspoon.moonspoon.dto.request.user;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CheckUsernameRequest {
+    @NotBlank(message = "아이디를 입력하세요.")
+    private String username;
+}

--- a/src/main/java/com/moonspoon/moonspoon/dto/request/user/CheckUsernameRequest.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/request/user/CheckUsernameRequest.java
@@ -1,6 +1,8 @@
 package com.moonspoon.moonspoon.dto.request.user;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,5 +10,7 @@ import lombok.Setter;
 @Setter
 public class CheckUsernameRequest {
     @NotBlank(message = "아이디를 입력하세요.")
+    @Size(min = 4, max = 20)
+    @Pattern(regexp = "^[a-zA-Z0-9]+$", message = "아이디는 영문과 숫자로 이루어져야 합니다.")
     private String username;
 }

--- a/src/main/java/com/moonspoon/moonspoon/dto/request/user/UserSignupRequest.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/request/user/UserSignupRequest.java
@@ -3,6 +3,8 @@ package com.moonspoon.moonspoon.dto.request.user;
 import com.moonspoon.moonspoon.domain.User;
 import com.moonspoon.moonspoon.domain.UserRole;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,9 +13,13 @@ import lombok.Setter;
 public class UserSignupRequest {
 
     @NotBlank(message = "아이디를 입력하세요.")
+    @Size(min = 4, max = 20)
+    @Pattern(regexp = "^[a-zA-Z0-9]+$", message = "아이디는 영문과 숫자로 이루어져야 합니다.")
     private String username;
 
     @NotBlank(message = "이름을 입력하세요.")
+    @Size(min = 4, max = 16)
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣\\s_-]+$", message = "특수문자는 허용되지 않습니다.")
     private String name;
 
     @NotBlank(message = "비밀번호를 입력하세요.")

--- a/src/main/java/com/moonspoon/moonspoon/dto/request/user/UserSignupRequest.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/request/user/UserSignupRequest.java
@@ -23,6 +23,8 @@ public class UserSignupRequest {
     private String name;
 
     @NotBlank(message = "비밀번호를 입력하세요.")
+    @Size(min = 4, max = 24)
+    @Pattern(regexp = "^[a-zA-Z0-9]+$", message = "비밀번호는 영문과 숫자로 이루어져야 합니다.")
     private String password;
 
     public static User toEntity(UserSignupRequest dto){

--- a/src/main/java/com/moonspoon/moonspoon/dto/request/user/UserSignupRequest.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/request/user/UserSignupRequest.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 public class UserSignupRequest {
 
     @NotBlank(message = "아이디를 입력하세요.")
-    @Size(min = 4, max = 20)
+    @Size(min = 2, max = 20)
     @Pattern(regexp = "^[a-zA-Z0-9]+$", message = "아이디는 영문과 숫자로 이루어져야 합니다.")
     private String username;
 
@@ -23,7 +23,7 @@ public class UserSignupRequest {
     private String name;
 
     @NotBlank(message = "비밀번호를 입력하세요.")
-    @Size(min = 4, max = 24)
+    @Size(min = 6, max = 24)
     @Pattern(regexp = "^[a-zA-Z0-9]+$", message = "비밀번호는 영문과 숫자로 이루어져야 합니다.")
     private String password;
 

--- a/src/main/java/com/moonspoon/moonspoon/dto/response/error/DuplicateErrorResponse.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/response/error/DuplicateErrorResponse.java
@@ -1,0 +1,14 @@
+package com.moonspoon.moonspoon.dto.response.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class DuplicateErrorResponse {
+    private String message;
+    private boolean validate;
+
+}

--- a/src/main/java/com/moonspoon/moonspoon/dto/response/error/ErrorResponse.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/response/error/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.moonspoon.moonspoon.exception;
+package com.moonspoon.moonspoon.dto.response.error;
 
 import lombok.*;
 

--- a/src/main/java/com/moonspoon/moonspoon/dto/response/user/UserCheckResponse.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/response/user/UserCheckResponse.java
@@ -1,0 +1,11 @@
+package com.moonspoon.moonspoon.dto.response.user;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserCheckResponse {
+    private String message;
+    private boolean validate;
+}

--- a/src/main/java/com/moonspoon/moonspoon/dto/response/user/UserResponse.java
+++ b/src/main/java/com/moonspoon/moonspoon/dto/response/user/UserResponse.java
@@ -1,4 +1,4 @@
-package com.moonspoon.moonspoon.dto.response;
+package com.moonspoon.moonspoon.dto.response.user;
 
 import com.moonspoon.moonspoon.domain.User;
 import lombok.Builder;

--- a/src/main/java/com/moonspoon/moonspoon/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/moonspoon/moonspoon/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.moonspoon.moonspoon.exception;
 
+import com.moonspoon.moonspoon.dto.response.error.DuplicateErrorResponse;
+import com.moonspoon.moonspoon.dto.response.error.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -8,9 +10,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @ControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(DuplicateUserException.class)
-    public ResponseEntity<ErrorResponse> handleDuplicateUserException(DuplicateUserException ex){
-        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    public ResponseEntity<DuplicateErrorResponse> handleDuplicateUserException(DuplicateUserException ex){
+        DuplicateErrorResponse errorResponse = new DuplicateErrorResponse(ex.getMessage(), false);
+        return ResponseEntity.badRequest().body(errorResponse);
     }
 
     @ExceptionHandler(NotUserException.class)

--- a/src/main/java/com/moonspoon/moonspoon/service/UserService.java
+++ b/src/main/java/com/moonspoon/moonspoon/service/UserService.java
@@ -1,7 +1,7 @@
 package com.moonspoon.moonspoon.service;
 import com.moonspoon.moonspoon.domain.User;
 import com.moonspoon.moonspoon.dto.request.user.UserSignupRequest;
-import com.moonspoon.moonspoon.dto.response.UserResponse;
+import com.moonspoon.moonspoon.dto.response.user.UserResponse;
 import com.moonspoon.moonspoon.exception.DuplicateUserException;
 import com.moonspoon.moonspoon.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +16,8 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
 
     public UserResponse signup(UserSignupRequest dto){
-        isDuplicated(dto.getUsername(), dto.getName());
+        isDuplicatedUsername(dto.getUsername());
+        isDuplicatedName(dto.getName());
         //비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(dto.getPassword());
         dto.setPassword(encodedPassword);
@@ -26,12 +27,17 @@ public class UserService {
         return UserResponse.fromEntity(user);
     }
 
-    private void isDuplicated(String username, String name){
+    public void isDuplicatedUsername(String username){
         if(userRepository.existsByUsername(username)) {
             throw new DuplicateUserException("중복된 아이디가 존재합니다.");
         }
-        else if(userRepository.existsByName(name)){
+    }
+
+    public void isDuplicatedName(String name){
+        if(userRepository.existsByName(name)){
             throw new DuplicateUserException("중복된 이름이 존재합니다.");
         }
     }
+
+
 }

--- a/src/main/java/com/moonspoon/moonspoon/service/UserService.java
+++ b/src/main/java/com/moonspoon/moonspoon/service/UserService.java
@@ -1,6 +1,7 @@
 package com.moonspoon.moonspoon.service;
 import com.moonspoon.moonspoon.domain.User;
 import com.moonspoon.moonspoon.dto.request.user.UserSignupRequest;
+import com.moonspoon.moonspoon.dto.response.error.DuplicateErrorResponse;
 import com.moonspoon.moonspoon.dto.response.user.UserResponse;
 import com.moonspoon.moonspoon.exception.DuplicateUserException;
 import com.moonspoon.moonspoon.repository.UserRepository;
@@ -27,16 +28,20 @@ public class UserService {
         return UserResponse.fromEntity(user);
     }
 
-    public void isDuplicatedUsername(String username){
+    public DuplicateErrorResponse isDuplicatedUsername(String username){
         if(userRepository.existsByUsername(username)) {
             throw new DuplicateUserException("중복된 아이디가 존재합니다.");
         }
+        DuplicateErrorResponse response = new DuplicateErrorResponse("OK", true);
+        return response;
     }
 
-    public void isDuplicatedName(String name){
+    public DuplicateErrorResponse isDuplicatedName(String name){
         if(userRepository.existsByName(name)){
             throw new DuplicateUserException("중복된 이름이 존재합니다.");
         }
+        DuplicateErrorResponse response = new DuplicateErrorResponse("OK", true);
+        return response;
     }
 
 

--- a/vue-cli/src/components/MyWorkbook.vue
+++ b/vue-cli/src/components/MyWorkbook.vue
@@ -185,7 +185,6 @@ export default {
               alert(error.response.data.message);
               this.$router.push("/mainPage");
             }
-
             console.log("ERROR", error);
       })
     },

--- a/vue-cli/src/components/MyWorkbook.vue
+++ b/vue-cli/src/components/MyWorkbook.vue
@@ -176,10 +176,16 @@ export default {
               console.log(error.response.data.message);
               alert("토큰이 만료되었습니다. 다시 로그인하세요.");
               localStorage.removeItem("token");
-            }else{
-              alert(error.response.data.message);
+              this.$router.push("/mainPage");
             }
-            this.$router.push("/mainPage");
+            else if(error.response.status === 404){
+              console.log("문제집 없음");
+            }
+            else{
+              alert(error.response.data.message);
+              this.$router.push("/mainPage");
+            }
+
             console.log("ERROR", error);
       })
     },

--- a/vue-cli/src/components/SignupForm.vue
+++ b/vue-cli/src/components/SignupForm.vue
@@ -30,6 +30,12 @@
         <p v-if="passwordError" class="error-message">{{ passwordError }}</p>
         <p v-if="isPasswordValid" class="success-message">올바른 비밀번호입니다.</p>
       </div>
+      <div class="input-group">
+        <label for="confirmPassword">Password 확인</label>
+        <input type="password" id="confirmPassword" v-model="confirmPassword" required placeholder="비밀번호 확인"
+               :class="{ 'error': confirmPasswordError, 'success': isConfirmPasswordValid }">
+        <p v-if="confirmPasswordError" class="error-message">{{ confirmPasswordError }}</p>
+      </div>
       <button type="submit" :disabled="!isFormValid">회원가입</button>
     </form>
     <p class="login-link">이미 계정이 있나요? <router-link to="/user/login">로그인</router-link></p>
@@ -46,6 +52,7 @@ export default {
       name: '',
       username: '',
       password: '',
+      confirmPassword: '',
       nameError: '',
       usernameError: '',
       passwordError: '',
@@ -57,10 +64,14 @@ export default {
   },
   computed: {
     isFormValid() {
-      return this.isNameValid && this.isUsernameValid && this.isPasswordValid;
+      return this.isNameValid && this.isUsernameValid
+          && this.isPasswordValid && this.isConfirmPasswordValid;
     },
     isPasswordValid() {
       return /^[A-Za-z0-9]{6,24}$/.test(this.password);
+    },
+    isConfirmPasswordValid() {
+      return this.password === this.confirmPassword && this.password !== '';
     },
     isNameFormatValid() {
       return this.name.length >= 4 && this.name.length < 16 && !/[!@#$%^&*(),.?":{}|<>]/.test(this.name);
@@ -82,6 +93,9 @@ export default {
     },
     password() {
       this.validatePassword();
+    },
+    confirmPassword() {
+      this.validateConfirmPassword();
     }
   },
   methods: {
@@ -101,6 +115,21 @@ export default {
         this.usernameError = '아이디는 영문과 숫자로만 6~12자로 구성되어야 합니다.';
       } else {
         this.usernameError = '';
+      }
+    },
+    validatePassword() {
+      if (!this.isPasswordValid) {
+        this.passwordError = '비밀번호는 영문과 숫자로만 6~12자로 구성되어야 합니다.';
+      } else {
+        this.passwordError = '';
+      }
+      this.validateConfirmPassword();
+    },
+    validateConfirmPassword() {
+      if (!this.isConfirmPasswordValid) {
+        this.confirmPasswordError = '비밀번호가 일치하지 않습니다.';
+      } else {
+        this.confirmPasswordError = '';
       }
     },
     checkNameDuplicate() {
@@ -138,13 +167,6 @@ export default {
             this.usernameSuccess = false;
             console.error(error);
           });
-    },
-    validatePassword() {
-      if (!this.isPasswordValid) {
-        this.passwordError = '비밀번호는 영문과 숫자로만 6~12자로 구성되어야 합니다.';
-      } else {
-        this.passwordError = '';
-      }
     },
     signup() {
       axios.post("/user/signup", {

--- a/vue-cli/src/components/SignupForm.vue
+++ b/vue-cli/src/components/SignupForm.vue
@@ -1,54 +1,37 @@
 <template>
+  <body>
   <div class="container">
     <h1 class="logo"><router-link to="/mainPage">Moon-Spoon</router-link></h1>
     <form @submit.prevent="signup">
       <div class="input-group">
         <label for="name">사용할 이름(닉네임)</label>
-        <input type="text" id="name" v-model="name" required placeholder="이름(닉네임)을 입력하세요."
-               :class="{ 'error': nameError }">
-        <button type="button" @click="checkNameDuplicate">중복확인</button>
-      </div>
+        <div class="input-with-button">
+          <input type="text" id="name" v-model="name" required placeholder="이름(닉네임)을 입력하세요."
+                 :class="{ 'error': nameError }">
+          <button type="button" @click="checkNameDuplicate">중복확인</button>
+        </div>
       <p v-if="nameError" class="error-message">{{ nameError }}</p>
       </div>
       <div class="input-group">
         <label for="userId">ID</label>
-        <input type="text" id="userId" v-model="username" required placeholder="아이디(영문 6~12자)"
-               :class="{ 'error': usernameError }">
-        <button type="button" @click="checkUsernameDuplicate">중복확인</button>
-      </div>
+        <div class="input-with-button">
+          <input type="text" id="userId" v-model="username" required placeholder="아이디(영문 6~12자)"
+                 :class="{ 'error': usernameError }">
+          <button type="button" @click="checkUsernameDuplicate">중복확인</button>
+        </div>
       <p v-if="usernameError" class="error-message">{{ usernameError }}</p>
-    <div class="container">
-      <h1 class="logo"><router-link to="/mainPage">Moon-Spoon</router-link></h1>
-      <form @submit.prevent="signup">
-        <div class="input-group">
-          <label for="name">사용할 이름(닉네임)</label>
-          <div class="input-with-button">
-            <input type="text" id="name" v-model="name" required placeholder="이름(닉네임)을 입력하세요."
-                   :class="{ 'error': nameError }">
-            <button type="button" @click="checkNameDuplicate">중복확인</button>
-          </div>
-          <p v-if="nameError" class="error-message">{{ nameError }}</p>
-        </div>
-        <div class="input-group">
-          <label for="userId">ID</label>
-          <div class="input-with-button">
-            <input type="text" id="userId" v-model="username" required placeholder="아이디(영문 6~12자)"
-                   :class="{ 'error': usernameError }">
-            <button type="button" @click="checkUsernameDuplicate">중복확인</button>
-          </div>
-          <p v-if="usernameError" class="error-message">{{ usernameError }}</p>
-        </div>
+      </div>
       <div class="input-group">
-        <label for="password">Password</label>
-        <input type="password" id="password" v-model="password" required placeholder="비밀번호(영문, 숫자 6~12자)"
-               :class="{'error': passwordError }">
-        <p v-if="passwordError" class="error-message">{{ passwordError }}</p>
+      <label for="password">Password</label>
+      <input type="password" id="password" v-model="password" required placeholder="비밀번호(영문, 숫자 6~12자)"
+             :class="{ 'error': passwordError }">
+      <p v-if="passwordError" class="error-message">{{ passwordError }}</p>
       </div>
       <button type="submit" :disabled="!isFormValid">회원가입</button>
     </form>
     <p class="login-link">이미 계정이 있나요? <router-link to="/user/login">로그인</router-link></p>
   </div>
-
+  </body>
 </template>
 
 <script>
@@ -255,6 +238,8 @@ a {
 
 .input-with-button button {
   padding: 0.5rem 1rem;
+  color: #1B2A49;
+  width: 140px;
   margin-top: 0;
 }
 

--- a/vue-cli/src/components/SignupForm.vue
+++ b/vue-cli/src/components/SignupForm.vue
@@ -6,7 +6,7 @@
       <div class="input-group">
         <label for="name">사용할 이름(닉네임)</label>
         <div class="input-with-button">
-          <input type="text" id="name" v-model="name" required placeholder="이름(닉네임)(4~16자)"
+          <input type="text" id="name" v-model="name" required placeholder="이름(닉네임)(2~16자)"
                  :class="{ 'error': nameError, 'success': nameSuccess}">
           <button type="button" @click="checkNameDuplicate">중복확인</button>
         </div>
@@ -16,7 +16,7 @@
       <div class="input-group">
         <label for="userId">ID</label>
         <div class="input-with-button">
-          <input type="text" id="userId" v-model="username" required placeholder="아이디(영문 6~12자)"
+          <input type="text" id="userId" v-model="username" required placeholder="아이디(영문 6~20자)"
                  :class="{ 'error': usernameError, 'success': usernameSuccess  }">
           <button type="button" @click="checkUsernameDuplicate">중복확인</button>
         </div>
@@ -75,7 +75,7 @@ export default {
       return this.password === this.confirmPassword && this.password !== '';
     },
     isNameFormatValid() {
-      return this.name.length >= 4 && this.name.length < 16 && !/[!@#$%^&*(),.?":{}|<>]/.test(this.name);
+      return this.name.length >= 2 && this.name.length < 16 && !/[!@#$%^&*(),.?":{}|<>]/.test(this.name);
     },
     isUsernameFormatValid() {
       return /^[A-Za-z0-9]{6,20}$/.test(this.username);
@@ -104,7 +104,7 @@ export default {
       this.isNameValid = false;
       this.nameSuccess = false;
       if (!this.isNameFormatValid) {
-        this.nameError = '닉네임은 4~20자 사이여야 하며 특수문자를 포함할 수 없습니다.';
+        this.nameError = '닉네임은 2~16자 사이여야 하며 특수문자를 포함할 수 없습니다.';
       } else {
         this.nameError = '';
       }
@@ -113,14 +113,14 @@ export default {
       this.isUsernameValid = false;
       this.usernameSuccess = false;
       if (!this.isUsernameFormatValid) {
-        this.usernameError = '아이디는 영문과 숫자로만 6~12자로 구성되어야 합니다.';
+        this.usernameError = '아이디는 영문과 숫자로만 6~20자로 구성되어야 합니다.';
       } else {
         this.usernameError = '';
       }
     },
     validatePassword() {
       if (!this.isPasswordValid) {
-        this.passwordError = '비밀번호는 영문과 숫자로만 6~12자로 구성되어야 합니다.';
+        this.passwordError = '비밀번호는 영문과 숫자로만 6~24자로 구성되어야 합니다.';
       } else {
         this.passwordError = '';
       }

--- a/vue-cli/src/components/SignupForm.vue
+++ b/vue-cli/src/components/SignupForm.vue
@@ -169,20 +169,25 @@ export default {
           });
     },
     signup() {
-      axios.post("/user/signup", {
-        name: this.name,
-        username: this.username,
-        password: this.password
-      })
-          .then((res) =>{
-            alert("회원가입 성공!");
-            this.$router.push("/user/login");
-            console.log("회원가입 성공", res);
-          })
-          .catch((error) => {
-            alert(error.response.data.message);
-            console.log("로그인 실패", error);
-          })
+      if (this.isFormValid){
+        axios.post("/user/signup", {
+          name: this.name,
+          username: this.username,
+          password: this.password
+        })
+            .then((res) =>{
+              alert("회원가입 성공!");
+              this.$router.push("/user/login");
+              console.log("회원가입 성공", res);
+            })
+            .catch((error) => {
+              alert(error.response.data.message);
+              console.log("로그인 실패", error);
+            })
+      }else{
+        alert("모든 필드를 올바르게 입력해주세요.");
+      }
+
     }
   }
 }

--- a/vue-cli/src/components/SignupForm.vue
+++ b/vue-cli/src/components/SignupForm.vue
@@ -53,6 +53,7 @@ export default {
       username: '',
       password: '',
       confirmPassword: '',
+      confirmPasswordError: '',
       nameError: '',
       usernameError: '',
       passwordError: '',
@@ -145,7 +146,11 @@ export default {
             }
           })
           .catch(error => {
-            this.nameError = '이름 중복 확인 중 오류가 발생했습니다.';
+            if(error.response.data.validate === false){
+              this.nameError = '이미 사용 중인 이름입니다.';
+            }else{
+              this.nameError = '이름 중복 확인 중 오류가 발생했습니다.';
+            }
             this.nameSuccess = false;
             console.error(error);
           });
@@ -163,7 +168,11 @@ export default {
             }
           })
           .catch(error => {
-            this.usernameError = '아이디 중복 확인 중 오류가 발생했습니다.';
+            if(error.response.data.validate === false){
+              this.usernameError = '이미 사용 중인 아이디입니다.';
+            }else{
+              this.usernameError = '아이디 중복 확인 중 오류가 발생했습니다.';
+            }
             this.usernameSuccess = false;
             console.error(error);
           });

--- a/vue-cli/src/components/SignupForm.vue
+++ b/vue-cli/src/components/SignupForm.vue
@@ -1,25 +1,53 @@
 <template>
-  <body>
   <div class="container">
     <h1 class="logo"><router-link to="/mainPage">Moon-Spoon</router-link></h1>
     <form @submit.prevent="signup">
       <div class="input-group">
         <label for="name">사용할 이름(닉네임)</label>
-        <input type="text" id="name" v-model="name" required placeholder="이름(닉네임)을 입력하세요.">
+        <input type="text" id="name" v-model="name" required placeholder="이름(닉네임)을 입력하세요."
+               :class="{ 'error': nameError }">
+        <button type="button" @click="checkNameDuplicate">중복확인</button>
+      </div>
+      <p v-if="nameError" class="error-message">{{ nameError }}</p>
       </div>
       <div class="input-group">
         <label for="userId">ID</label>
-        <input type="text" id="userId" v-model="username" required placeholder="아이디(영문 6~12자)">
+        <input type="text" id="userId" v-model="username" required placeholder="아이디(영문 6~12자)"
+               :class="{ 'error': usernameError }">
+        <button type="button" @click="checkUsernameDuplicate">중복확인</button>
       </div>
+      <p v-if="usernameError" class="error-message">{{ usernameError }}</p>
+    <div class="container">
+      <h1 class="logo"><router-link to="/mainPage">Moon-Spoon</router-link></h1>
+      <form @submit.prevent="signup">
+        <div class="input-group">
+          <label for="name">사용할 이름(닉네임)</label>
+          <div class="input-with-button">
+            <input type="text" id="name" v-model="name" required placeholder="이름(닉네임)을 입력하세요."
+                   :class="{ 'error': nameError }">
+            <button type="button" @click="checkNameDuplicate">중복확인</button>
+          </div>
+          <p v-if="nameError" class="error-message">{{ nameError }}</p>
+        </div>
+        <div class="input-group">
+          <label for="userId">ID</label>
+          <div class="input-with-button">
+            <input type="text" id="userId" v-model="username" required placeholder="아이디(영문 6~12자)"
+                   :class="{ 'error': usernameError }">
+            <button type="button" @click="checkUsernameDuplicate">중복확인</button>
+          </div>
+          <p v-if="usernameError" class="error-message">{{ usernameError }}</p>
+        </div>
       <div class="input-group">
         <label for="password">Password</label>
-        <input type="password" id="password" v-model="password" required placeholder="비밀번호(영문 6~12자)">
+        <input type="password" id="password" v-model="password" required placeholder="비밀번호(영문, 숫자 6~12자)"
+               :class="{'error': passwordError }">
+        <p v-if="passwordError" class="error-message">{{ passwordError }}</p>
       </div>
-      <button type="submit">회원가입</button>
+      <button type="submit" :disabled="!isFormValid">회원가입</button>
     </form>
     <p class="login-link">이미 계정이 있나요? <router-link to="/user/login">로그인</router-link></p>
   </div>
-  </body>
 
 </template>
 
@@ -31,10 +59,73 @@ export default {
     return {
       name: '',
       username: '',
-      password: ''
+      password: '',
+      nameError: '',
+      usernameError: '',
+      passwordError: '',
+      isNameValid: false,
+      isUsernameValid: false
+    }
+  },
+  computed: {
+    isFormValid() {
+      return this.isNameValid && this.isUsernameValid && this.isPasswordValid;
+    },
+    isPasswordValid() {
+      return /^[A-Za-z0-9]{6,12}$/.test(this.password);
+    }
+  },
+  watch: {
+    name() {
+      this.isNameValid = false;
+      this.nameError = '';
+    },
+    username() {
+      this.isUsernameValid = false;
+      this.usernameError = '';
+    },
+    password() {
+      this.validatePassword();
     }
   },
   methods: {
+    checkNameDuplicate() {
+      axios.post("/user/check-name", { name: this.name })
+          .then(response => {
+            if (response.data.validate) {
+              this.isNameValid = true;
+              this.nameError = '';
+            } else {
+              this.nameError = '이미 사용 중인 이름입니다.';
+            }
+          })
+          .catch(error => {
+            this.nameError = '이름 중복 확인 중 오류가 발생했습니다.';
+            console.error(error);
+          });
+    },
+    checkUsernameDuplicate() {
+      axios.post("/user/check-username", { username: this.username })
+          .then(response => {
+            if (response.data.validate) {
+              this.isUsernameValid = true;
+              this.usernameError = '';
+            } else {
+              this.usernameError = '이미 사용 중인 아이디입니다.';
+            }
+          })
+          .catch(error => {
+            this.usernameError = '아이디 중복 확인 중 오류가 발생했습니다.';
+            console.error(error);
+          });
+    },
+    validatePassword() {
+      if (!this.isPasswordValid) {
+        this.passwordError = '비밀번호는 영문과 숫자로만 6~12자로 구성되어야 합니다.';
+      } else {
+        this.passwordError = '';
+      }
+    },
     signup() {
       // 여기에 회원가입 로직을 구현하세요
       axios.post("/user/signup", {
@@ -153,7 +244,27 @@ a {
   font-weight: bold;
 }
 
-a:hover {
+.input-with-button {
+  display: flex;
+  gap: 10px;
+}
 
+.input-with-button input {
+  flex-grow: 1;
+}
+
+.input-with-button button {
+  padding: 0.5rem 1rem;
+  margin-top: 0;
+}
+
+.error {
+  border-color: red;
+}
+
+.error-message {
+  color: red;
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
 }
 </style>

--- a/vue-cli/src/components/SignupForm.vue
+++ b/vue-cli/src/components/SignupForm.vue
@@ -309,14 +309,17 @@ a {
   color: red;
   font-size: 0.9rem;
   margin-top: 0.5rem;
+  position: absolute;
 }
 .success {
   border-color: green;
 }
 
 .success-message {
-  color: green;
+  color: rgba(0,255,32,0.89);
   font-size: 0.9rem;
   margin-top: 0.5rem;
+  position: absolute;
 }
+
 </style>


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/43 -> main

### 변경 사항
회원가입시 입력값에 대한 유효성 검사를 메시지로 표시했습니다.  
이름, 아이디, 비밀번호 입력값의 문자 제한, 길이 제한을 표시합니다.  
중복 검사를 구현하고 비밀번호 확인 기능을 구현했습니다.  

### 테스트 결과
이름 중복 검사
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/19dfd9cb-c1a4-4566-bc45-8fe8380672b0)
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/a5a33d07-01b7-46e7-a44b-c666870720a5)

아이디 중복 검사
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/41314cec-9d1f-473a-afb2-bd07f78c79bf)
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/7ab6e549-4ae4-4ada-b262-9d5efc357b60)

비밀번호
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/b75ba228-c00c-45fb-9171-631518d1bd1c)
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/bf4e4143-35aa-49c0-8dfa-2ef65d8a23fb)

### 코멘트

