### PR TITLE
[FIX] 회원가입 동시성 문제 해결 (#45)

### DIFF
--- a/src/main/java/com/moonspoon/moonspoon/domain/User.java
+++ b/src/main/java/com/moonspoon/moonspoon/domain/User.java
@@ -19,8 +19,13 @@ public class User {
     @GeneratedValue
     @Column(name = "user_id")
     private Long id;
+
+    @Column(unique = true)
     private String username;
+
+    @Column(unique = true)
     private String name;
+
     private String password;
 
     private UserRole role;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: true

--- a/src/test/java/com/moonspoon/moonspoon/TestUser.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUser.java
@@ -6,11 +6,13 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
+@Table(name = "test_user", uniqueConstraints = @UniqueConstraint(columnNames = "name"))
 public class TestUser {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true)
     private String name;
 
     @Version

--- a/src/test/java/com/moonspoon/moonspoon/TestUser.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUser.java
@@ -3,6 +3,8 @@ package com.moonspoon.moonspoon;
 
 import jakarta.persistence.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 public class TestUser {
     @Id
@@ -13,6 +15,16 @@ public class TestUser {
 
     @Version
     private Long version;
+
+    private LocalDateTime createDate;
+
+    public LocalDateTime getCreateDate() {
+        return createDate;
+    }
+
+    public void setCreateDate(LocalDateTime createDate) {
+        this.createDate = createDate;
+    }
 
     public Long getId() {
         return id;

--- a/src/test/java/com/moonspoon/moonspoon/TestUser.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUser.java
@@ -6,7 +6,7 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "test_user", uniqueConstraints = @UniqueConstraint(columnNames = "name"))
+//@Table(name = "test_user", uniqueConstraints = @UniqueConstraint(columnNames = "name"))
 public class TestUser {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -14,6 +14,16 @@ public class TestUser {
 
     @Column(unique = true)
     private String name;
+
+    public String getSynName() {
+        return synName;
+    }
+
+    public void setSynName(String synName) {
+        this.synName = synName;
+    }
+
+    private String synName;
 
     private String password;
 

--- a/src/test/java/com/moonspoon/moonspoon/TestUser.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUser.java
@@ -1,0 +1,40 @@
+package com.moonspoon.moonspoon;
+
+
+import jakarta.persistence.*;
+
+@Entity
+public class TestUser {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Version
+    private Long version;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setVersion(Long version) {
+        this.version = version;
+    }
+}

--- a/src/test/java/com/moonspoon/moonspoon/TestUser.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUser.java
@@ -15,6 +15,18 @@ public class TestUser {
     @Column(unique = true)
     private String name;
 
+    private String password;
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+
+
     @Version
     private Long version;
 

--- a/src/test/java/com/moonspoon/moonspoon/TestUser.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUser.java
@@ -26,10 +26,6 @@ public class TestUser {
     }
 
 
-
-    @Version
-    private Long version;
-
     private LocalDateTime createDate;
 
     public LocalDateTime getCreateDate() {
@@ -48,10 +44,6 @@ public class TestUser {
         return name;
     }
 
-    public Long getVersion() {
-        return version;
-    }
-
     public void setId(Long id) {
         this.id = id;
     }
@@ -60,7 +52,4 @@ public class TestUser {
         this.name = name;
     }
 
-    public void setVersion(Long version) {
-        this.version = version;
-    }
 }

--- a/src/test/java/com/moonspoon/moonspoon/TestUserRepository.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUserRepository.java
@@ -1,9 +1,20 @@
 package com.moonspoon.moonspoon;
 
+
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface TestUserRepository extends JpaRepository<TestUser, Long> {
     boolean existsByName(String name);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT u FROM TestUser u WHERE u.name = :name")
+    Optional<TestUser> findByNameForUpdate(@Param("name") String name);
 }

--- a/src/test/java/com/moonspoon/moonspoon/TestUserRepository.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUserRepository.java
@@ -5,4 +5,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TestUserRepository extends JpaRepository<TestUser, Long> {
+    boolean existsByName(String name);
 }

--- a/src/test/java/com/moonspoon/moonspoon/TestUserRepository.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUserRepository.java
@@ -13,8 +13,4 @@ import java.util.Optional;
 @Repository
 public interface TestUserRepository extends JpaRepository<TestUser, Long> {
     boolean existsByName(String name);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT u FROM TestUser u WHERE u.name = :name")
-    Optional<TestUser> findByNameForUpdate(@Param("name") String name);
 }

--- a/src/test/java/com/moonspoon/moonspoon/TestUserRepository.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUserRepository.java
@@ -13,4 +13,6 @@ import java.util.Optional;
 @Repository
 public interface TestUserRepository extends JpaRepository<TestUser, Long> {
     boolean existsByName(String name);
+
+    boolean existsBySynName(String synName);
 }

--- a/src/test/java/com/moonspoon/moonspoon/TestUserRepository.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUserRepository.java
@@ -1,0 +1,8 @@
+package com.moonspoon.moonspoon;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TestUserRepository extends JpaRepository<TestUser, Long> {
+}

--- a/src/test/java/com/moonspoon/moonspoon/TestUserService.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUserService.java
@@ -4,16 +4,17 @@ import com.moonspoon.moonspoon.exception.DuplicateUserException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
 @Service
+
 public class TestUserService {
     @Autowired
     private TestUserRepository repository;
-
     @Transactional
     public void signup(TestUser testUser){
         testUser.setCreateDate(LocalDateTime.now());
@@ -26,6 +27,13 @@ public class TestUserService {
             throw new IllegalStateException("동시성 문제 발견됨", e);
         }
     }
-
+    @Transactional
+    public void signupPessimistic(TestUser testUser){
+        testUser.setCreateDate(LocalDateTime.now());
+        if(repository.findByNameForUpdate(testUser.getName()).isPresent()){
+            throw new DuplicateUserException("존재하는 이름입니다.");
+        }
+        repository.save(testUser);
+    }
 
 }

--- a/src/test/java/com/moonspoon/moonspoon/TestUserService.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUserService.java
@@ -30,7 +30,6 @@ public class TestUserService {
         }
     }
 
-    @Transactional
     public synchronized void signupSynchronized(TestUser testUser){
         testUser.setCreateDate(LocalDateTime.now());
         if(repository.existsBySynName(testUser.getSynName())){

--- a/src/test/java/com/moonspoon/moonspoon/TestUserService.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUserService.java
@@ -9,12 +9,14 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 
 public class TestUserService {
     @Autowired
     private TestUserRepository repository;
+
     @Transactional
     public void signup(TestUser testUser){
         testUser.setCreateDate(LocalDateTime.now());
@@ -30,7 +32,8 @@ public class TestUserService {
     @Transactional
     public void signupPessimistic(TestUser testUser){
         testUser.setCreateDate(LocalDateTime.now());
-        if(repository.findByNameForUpdate(testUser.getName()).isPresent()){
+        Optional<TestUser> existingUser = repository.findByNameForUpdate(testUser.getName());
+        if(existingUser.isPresent()){
             throw new DuplicateUserException("존재하는 이름입니다.");
         }
         repository.save(testUser);

--- a/src/test/java/com/moonspoon/moonspoon/TestUserService.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUserService.java
@@ -1,5 +1,6 @@
 package com.moonspoon.moonspoon;
 
+import com.moonspoon.moonspoon.exception.DuplicateUserException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -7,11 +8,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class TestUserService {
     @Autowired
-    private TestUserRepository testUserRepository;
+    private TestUserRepository repository;
 
     @Transactional
-    public TestUser signup(TestUser testUser){
-        return testUserRepository.save(testUser);
+    public void signup(TestUser testUser){
+        if(repository.existsByName(testUser.getName())){
+            throw new DuplicateUserException("존재하는 이름입니다.");
+        }
+        repository.save(testUser);
     }
 
 

--- a/src/test/java/com/moonspoon/moonspoon/TestUserService.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUserService.java
@@ -2,8 +2,11 @@ package com.moonspoon.moonspoon;
 
 import com.moonspoon.moonspoon.exception.DuplicateUserException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 public class TestUserService {
@@ -12,10 +15,15 @@ public class TestUserService {
 
     @Transactional
     public void signup(TestUser testUser){
+        testUser.setCreateDate(LocalDateTime.now());
         if(repository.existsByName(testUser.getName())){
             throw new DuplicateUserException("존재하는 이름입니다.");
         }
-        repository.save(testUser);
+        try{
+            repository.save(testUser);
+        }catch (ObjectOptimisticLockingFailureException e){
+            throw new IllegalStateException("동시성 문제 발견됨", e);
+        }
     }
 
 

--- a/src/test/java/com/moonspoon/moonspoon/TestUserService.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUserService.java
@@ -18,7 +18,7 @@ public class TestUserService {
     private TestUserRepository repository;
 
     @Transactional
-    public void signup(TestUser testUser){
+    public void signupUnique(TestUser testUser){
         testUser.setCreateDate(LocalDateTime.now());
         if(repository.existsByName(testUser.getName())){
             throw new DuplicateUserException("존재하는 이름입니다.");
@@ -30,4 +30,16 @@ public class TestUserService {
         }
     }
 
+    @Transactional
+    public synchronized void signupSynchronized(TestUser testUser){
+        testUser.setCreateDate(LocalDateTime.now());
+        if(repository.existsBySynName(testUser.getSynName())){
+            throw new DuplicateUserException("존재하는 이름입니다.");
+        }
+        try{
+            repository.save(testUser);
+        }catch (ObjectOptimisticLockingFailureException e){
+            throw new IllegalStateException("동시성 문제 발견됨", e);
+        }
+    }
 }

--- a/src/test/java/com/moonspoon/moonspoon/TestUserService.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUserService.java
@@ -1,0 +1,18 @@
+package com.moonspoon.moonspoon;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TestUserService {
+    @Autowired
+    private TestUserRepository testUserRepository;
+
+    @Transactional
+    public TestUser signup(TestUser testUser){
+        return testUserRepository.save(testUser);
+    }
+
+
+}

--- a/src/test/java/com/moonspoon/moonspoon/TestUserService.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUserService.java
@@ -4,6 +4,7 @@ import com.moonspoon.moonspoon.exception.DuplicateUserException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;

--- a/src/test/java/com/moonspoon/moonspoon/TestUserService.java
+++ b/src/test/java/com/moonspoon/moonspoon/TestUserService.java
@@ -29,14 +29,5 @@ public class TestUserService {
             throw new IllegalStateException("동시성 문제 발견됨", e);
         }
     }
-    @Transactional
-    public void signupPessimistic(TestUser testUser){
-        testUser.setCreateDate(LocalDateTime.now());
-        Optional<TestUser> existingUser = repository.findByNameForUpdate(testUser.getName());
-        if(existingUser.isPresent()){
-            throw new DuplicateUserException("존재하는 이름입니다.");
-        }
-        repository.save(testUser);
-    }
 
 }

--- a/src/test/java/com/moonspoon/moonspoon/user/UserServiceTest.java
+++ b/src/test/java/com/moonspoon/moonspoon/user/UserServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.concurrent.CountDownLatch;
@@ -32,7 +33,7 @@ public class UserServiceTest {
         //given
         TestUser user = new TestUser();
         user.setName("userA");
-        int threadCount = 50;
+        int threadCount = 20;
         CountDownLatch latch = new CountDownLatch(threadCount);
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
 

--- a/src/test/java/com/moonspoon/moonspoon/user/UserServiceTest.java
+++ b/src/test/java/com/moonspoon/moonspoon/user/UserServiceTest.java
@@ -30,6 +30,7 @@ public class UserServiceTest {
     private TestUserRepository repository;
 
     @Test
+    @DisplayName("유니크 제약 테스트")
     void concurrentSignupTest() throws InterruptedException{
         int threadCount = 200;
         CountDownLatch latch = new CountDownLatch(threadCount);
@@ -58,6 +59,7 @@ public class UserServiceTest {
 
     }
     @Test
+    @DisplayName("Synchronized 테스트")
     void concurrentSignupSynTest() throws InterruptedException{
         int threadCount = 200;
         CountDownLatch latch = new CountDownLatch(threadCount);

--- a/src/test/java/com/moonspoon/moonspoon/user/UserServiceTest.java
+++ b/src/test/java/com/moonspoon/moonspoon/user/UserServiceTest.java
@@ -41,7 +41,7 @@ public class UserServiceTest {
                 try {
                     TestUser user = new TestUser();
                     user.setName("userA");
-                    service.signup(user);
+                    service.signupUnique(user);
                 } catch (Exception e) {
                     System.out.println("Exception occurred: " + e.getMessage());
                 } finally {
@@ -54,7 +54,31 @@ public class UserServiceTest {
         assertEquals(1, repository.count());
 
     }
+    @Test
+    void concurrentSignupSynTest() throws InterruptedException{
+        //given
+        int threadCount = 20;
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
 
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    TestUser user = new TestUser();
+                    user.setSynName("userA");
+                    service.signupUnique(user);
+                } catch (Exception e) {
+                    System.out.println("Exception occurred: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        assertEquals(1, repository.count());
+
+    }
     @AfterEach
     void tearDown() {
         repository.deleteAll();

--- a/src/test/java/com/moonspoon/moonspoon/user/UserServiceTest.java
+++ b/src/test/java/com/moonspoon/moonspoon/user/UserServiceTest.java
@@ -3,13 +3,14 @@ package com.moonspoon.moonspoon.user;
 import com.moonspoon.moonspoon.TestUser;
 import com.moonspoon.moonspoon.TestUserRepository;
 import com.moonspoon.moonspoon.TestUserService;
-import com.moonspoon.moonspoon.repository.UserRepository;
-import com.moonspoon.moonspoon.service.UserService;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
+
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.concurrent.CountDownLatch;
@@ -20,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Transactional
 public class UserServiceTest {
     @Autowired
     private TestUserService service;
@@ -54,6 +56,7 @@ public class UserServiceTest {
     }
 
     @Test
+    @DisplayName("같은 이름으로 20번의 회원 동시 가입")
     void concurrentSignupPessimisticLockTest() throws InterruptedException{
         //given
 
@@ -79,5 +82,8 @@ public class UserServiceTest {
         assertEquals(1, repository.count());
 
     }
-
+    @AfterEach
+    void tearDown() {
+        repository.deleteAll();
+    }
 }

--- a/src/test/java/com/moonspoon/moonspoon/user/UserServiceTest.java
+++ b/src/test/java/com/moonspoon/moonspoon/user/UserServiceTest.java
@@ -1,0 +1,27 @@
+package com.moonspoon.moonspoon.user;
+
+import com.moonspoon.moonspoon.TestUserRepository;
+import com.moonspoon.moonspoon.TestUserService;
+import com.moonspoon.moonspoon.repository.UserRepository;
+import com.moonspoon.moonspoon.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class UserServiceTest {
+    @Autowired
+    private TestUserService testUserService;
+
+    @Autowired
+    private TestUserRepository testUserRepository;
+
+    @Test
+    void concurrentSignupTest(){
+
+
+    }
+
+}

--- a/src/test/java/com/moonspoon/moonspoon/user/UserServiceTest.java
+++ b/src/test/java/com/moonspoon/moonspoon/user/UserServiceTest.java
@@ -69,6 +69,7 @@ public class UserServiceTest {
                 try {
                     TestUser user = new TestUser();
                     user.setName("userA");
+                    user.setPassword("ps");
                     service.signupPessimistic(user);
                 } catch (Exception e) {
                     System.out.println("Exception occurred: " + e.getMessage());

--- a/src/test/java/com/moonspoon/moonspoon/user/UserServiceTest.java
+++ b/src/test/java/com/moonspoon/moonspoon/user/UserServiceTest.java
@@ -31,10 +31,11 @@ public class UserServiceTest {
 
     @Test
     void concurrentSignupTest() throws InterruptedException{
-        //given
-        int threadCount = 20;
+        int threadCount = 200;
         CountDownLatch latch = new CountDownLatch(threadCount);
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+
+        long startTime = System.currentTimeMillis();
 
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {
@@ -49,24 +50,27 @@ public class UserServiceTest {
                 }
             });
         }
+        long endTime = System.currentTimeMillis();
 
+        System.out.println("Unique Key Time: " + (endTime - startTime) + "ms");
         latch.await();
         assertEquals(1, repository.count());
 
     }
     @Test
     void concurrentSignupSynTest() throws InterruptedException{
-        //given
-        int threadCount = 20;
+        int threadCount = 200;
         CountDownLatch latch = new CountDownLatch(threadCount);
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+
+        long startTime = System.currentTimeMillis();
 
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {
                 try {
                     TestUser user = new TestUser();
                     user.setSynName("userA");
-                    service.signupUnique(user);
+                    service.signupSynchronized(user);
                 } catch (Exception e) {
                     System.out.println("Exception occurred: " + e.getMessage());
                 } finally {
@@ -74,7 +78,9 @@ public class UserServiceTest {
                 }
             });
         }
+        long endTime = System.currentTimeMillis();
 
+        System.out.println("Synchronized Time: " + (endTime - startTime) + "ms");
         latch.await();
         assertEquals(1, repository.count());
 

--- a/src/test/java/com/moonspoon/moonspoon/user/UserServiceTest.java
+++ b/src/test/java/com/moonspoon/moonspoon/user/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.moonspoon.moonspoon.user;
 
+import com.moonspoon.moonspoon.TestUser;
 import com.moonspoon.moonspoon.TestUserRepository;
 import com.moonspoon.moonspoon.TestUserService;
 import com.moonspoon.moonspoon.repository.UserRepository;
@@ -8,6 +9,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -19,9 +26,31 @@ public class UserServiceTest {
     private TestUserRepository testUserRepository;
 
     @Test
-    void concurrentSignupTest(){
+    void concurrentSignupTest() throws InterruptedException{
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
 
+        for (int i = 0; i < threadCount; i++) {
+            final int index = i;
+            executorService.submit(() -> {
+                try {
+                    TestUser user = new TestUser();
+                    user.setName("name" + index);
+                    // 회원가입 시도
+                    testUserService.signup(user);
+                } catch (Exception e) {
+                    // 예외 처리
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
 
+        latch.await();
+
+        // 모든 쓰레드가 실행을 완료한 후, 회원 수 검증
+        assertEquals(threadCount, testUserRepository.count());
     }
-
 }

--- a/src/test/java/com/moonspoon/moonspoon/user/UserServiceTest.java
+++ b/src/test/java/com/moonspoon/moonspoon/user/UserServiceTest.java
@@ -30,7 +30,7 @@ public class UserServiceTest {
     private TestUserRepository repository;
 
     @Test
-    void concurrentSignupOptimisticLockTest() throws InterruptedException{
+    void concurrentSignupTest() throws InterruptedException{
         //given
         int threadCount = 20;
         CountDownLatch latch = new CountDownLatch(threadCount);
@@ -55,34 +55,6 @@ public class UserServiceTest {
 
     }
 
-    @Test
-    @DisplayName("같은 이름으로 20번의 회원 동시 가입")
-    void concurrentSignupPessimisticLockTest() throws InterruptedException{
-        //given
-
-        int threadCount = 20;
-        CountDownLatch latch = new CountDownLatch(threadCount);
-        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-
-        for (int i = 0; i < threadCount; i++) {
-            executorService.submit(() -> {
-                try {
-                    TestUser user = new TestUser();
-                    user.setName("userA");
-                    user.setPassword("ps");
-                    service.signupPessimistic(user);
-                } catch (Exception e) {
-                    System.out.println("Exception occurred: " + e.getMessage());
-                } finally {
-                    latch.countDown();
-                }
-            });
-        }
-
-        latch.await();
-        assertEquals(1, repository.count());
-
-    }
     @AfterEach
     void tearDown() {
         repository.deleteAll();


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/45 -> main

### 변경 사항
같은 이름, 아이디로 회원가입이 되는 현상을 해결했습니다.

### 테스트 결과
![image](https://github.com/hamlsy/Moon-Spoon/assets/70877744/ee79df79-47a5-428b-9c48-58f03f47e263)

### 코멘트
처음에는 낙관락, 비관락으로 해결하려 했으나, 기존에 존재하던 값을 수정하는 것이 아닌 신규 등록 메커니즘이어서 동시성을 완벽히 해결할 수 없었습니다. 그래서 유니크 키 설정과 Synchronized 설정을 비교하여 유니크 키 설정이 적합하다고 판단했습니다. 자세한 내용은 이슈에 적어놓았습니다.

신규 등록이 아닌 기존 값을 동시에 Update하는 상황이 오면 락을 적용해보도록 하겠습니다.
